### PR TITLE
ENH: Support for multiple ``--output-spaces``

### DIFF
--- a/.circleci/ds054_outputs.txt
+++ b/.circleci/ds054_outputs.txt
@@ -13,8 +13,10 @@ smriprep/sub-100185/anat/sub-100185_desc-preproc_T1w.json
 smriprep/sub-100185/anat/sub-100185_desc-preproc_T1w.nii.gz
 smriprep/sub-100185/anat/sub-100185_dseg.nii.gz
 smriprep/sub-100185/anat/sub-100185_from-MNI152Lin_to-T1w_mode-image_xfm.h5
+smriprep/sub-100185/anat/sub-100185_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5
 smriprep/sub-100185/anat/sub-100185_from-orig_to-T1w_mode-image_xfm.txt
 smriprep/sub-100185/anat/sub-100185_from-T1w_to-MNI152Lin_mode-image_xfm.h5
+smriprep/sub-100185/anat/sub-100185_from-T1w_to-MNI152NLin2009cAsym_mode-image_xfm.h5
 smriprep/sub-100185/anat/sub-100185_label-CSF_probseg.nii.gz
 smriprep/sub-100185/anat/sub-100185_label-GM_probseg.nii.gz
 smriprep/sub-100185/anat/sub-100185_label-WM_probseg.nii.gz
@@ -26,5 +28,13 @@ smriprep/sub-100185/anat/sub-100185_space-MNI152Lin_dseg.nii.gz
 smriprep/sub-100185/anat/sub-100185_space-MNI152Lin_label-CSF_probseg.nii.gz
 smriprep/sub-100185/anat/sub-100185_space-MNI152Lin_label-GM_probseg.nii.gz
 smriprep/sub-100185/anat/sub-100185_space-MNI152Lin_label-WM_probseg.nii.gz
+smriprep/sub-100185/anat/sub-100185_space-MNI152NLin2009cAsym_desc-brain_mask.json
+smriprep/sub-100185/anat/sub-100185_space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz
+smriprep/sub-100185/anat/sub-100185_space-MNI152NLin2009cAsym_desc-preproc_T1w.json
+smriprep/sub-100185/anat/sub-100185_space-MNI152NLin2009cAsym_desc-preproc_T1w.nii.gz
+smriprep/sub-100185/anat/sub-100185_space-MNI152NLin2009cAsym_dseg.nii.gz
+smriprep/sub-100185/anat/sub-100185_space-MNI152NLin2009cAsym_label-CSF_probseg.nii.gz
+smriprep/sub-100185/anat/sub-100185_space-MNI152NLin2009cAsym_label-GM_probseg.nii.gz
+smriprep/sub-100185/anat/sub-100185_space-MNI152NLin2009cAsym_label-WM_probseg.nii.gz
 smriprep/sub-100185.html
 /tmp/ds054/derivatives

--- a/Dockerfile
+++ b/Dockerfile
@@ -101,9 +101,6 @@ ENV PATH=$ANTSPATH:$PATH
 # Installing SVGO
 RUN npm install -g svgo
 
-# Installing bids-validator
-RUN npm install -g bids-validator@1.1.0
-
 # Installing and setting up miniconda
 RUN curl -sSLO https://repo.continuum.io/miniconda/Miniconda3-4.5.11-Linux-x86_64.sh && \
     bash Miniconda3-4.5.11-Linux-x86_64.sh -b -p /usr/local/miniconda && \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 indexed_gzip>=0.8.8
 nilearn!=0.5.0,!=0.5.1
-git+https://github.com/oesteban/niworkflows.git@39928d76413e9d9d2c0e2286584d930bb3566c9a#egg=niworkflows
+git+https://github.com/oesteban/niworkflows.git@c769ec5e03e717650565da93f13c96032598202a#egg=niworkflows
 templateflow<0.2.0a0,>=0.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 indexed_gzip>=0.8.8
 nilearn!=0.5.0,!=0.5.1
-git+https://github.com/poldracklab/niworkflows.git@10ebae7b2e1f49716e10e22ab49bcfdf4b4db92e#egg=niworkflows
+niworkflows<0.10.0a0,>=0.9.0a0
 templateflow<0.2.0a0,>=0.1.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 indexed_gzip>=0.8.8
 nilearn!=0.5.0,!=0.5.1
-git+https://github.com/poldracklab/niworkflows.git@b7d111c8fd36a099c74be5e7671677eedb175533#egg=niworkflows
+git+https://github.com/poldracklab/niworkflows.git@2a2586f8e450a0246e8bd7616d2d60b86f704a47#egg=niworkflows
 templateflow<0.2.0a0,>=0.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 indexed_gzip>=0.8.8
 nilearn!=0.5.0,!=0.5.1
-git+https://github.com/poldracklab/niworkflows.git@2a2586f8e450a0246e8bd7616d2d60b86f704a47#egg=niworkflows
+git+https://github.com/poldracklab/niworkflows.git@0c09ee3d430875b86e670951575d29372812a213#egg=niworkflows
 templateflow<0.2.0a0,>=0.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 indexed_gzip>=0.8.8
 nilearn!=0.5.0,!=0.5.1
-git+https://github.com/poldracklab/niworkflows.git@0c09ee3d430875b86e670951575d29372812a213#egg=niworkflows
+git+https://github.com/oesteban/niworkflows.git@39928d76413e9d9d2c0e2286584d930bb3566c9a#egg=niworkflows
 templateflow<0.2.0a0,>=0.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 indexed_gzip>=0.8.8
 nilearn!=0.5.0,!=0.5.1
-git+https://github.com/oesteban/niworkflows.git@c769ec5e03e717650565da93f13c96032598202a#egg=niworkflows
-templateflow<0.2.0a0,>=0.1.3
+git+https://github.com/poldracklab/niworkflows.git@10ebae7b2e1f49716e10e22ab49bcfdf4b4db92e#egg=niworkflows
+templateflow<0.2.0a0,>=0.1.7

--- a/smriprep/__about__.py
+++ b/smriprep/__about__.py
@@ -54,13 +54,13 @@ REQUIRES = [
     'packaging',
     'pybids',
     'pyyaml',
-    'templateflow<0.2.0a0,>=0.1.3',
+    'templateflow<0.2.0a0,>=0.1.7',
 ]
 
 
 LINKS_REQUIRES = [
-    'git+https://github.com/oesteban/niworkflows.git@'
-    'c769ec5e03e717650565da93f13c96032598202a#egg=niworkflows',
+    'git+https://github.com/poldracklab/niworkflows.git@'
+    '10ebae7b2e1f49716e10e22ab49bcfdf4b4db92e#egg=niworkflows',
 ]
 
 TESTS_REQUIRES = [

--- a/smriprep/__about__.py
+++ b/smriprep/__about__.py
@@ -49,7 +49,7 @@ REQUIRES = [
     'matplotlib>=2.2.0',
     'nibabel>=2.2.1',
     'nipype>=1.1.6',
-    'niworkflows',
+    'niworkflows<0.10.0a0,>=0.9.0a0',
     'numpy',
     'packaging',
     'pybids',
@@ -59,8 +59,6 @@ REQUIRES = [
 
 
 LINKS_REQUIRES = [
-    'git+https://github.com/poldracklab/niworkflows.git@'
-    '10ebae7b2e1f49716e10e22ab49bcfdf4b4db92e#egg=niworkflows',
 ]
 
 TESTS_REQUIRES = [

--- a/smriprep/__about__.py
+++ b/smriprep/__about__.py
@@ -61,7 +61,7 @@ REQUIRES = [
 
 LINKS_REQUIRES = [
     'git+https://github.com/poldracklab/niworkflows.git@'
-    'b7d111c8fd36a099c74be5e7671677eedb175533#egg=niworkflows',
+    '2a2586f8e450a0246e8bd7616d2d60b86f704a47#egg=niworkflows',
 ]
 
 TESTS_REQUIRES = [

--- a/smriprep/__about__.py
+++ b/smriprep/__about__.py
@@ -61,7 +61,7 @@ REQUIRES = [
 
 LINKS_REQUIRES = [
     'git+https://github.com/poldracklab/niworkflows.git@'
-    '2a2586f8e450a0246e8bd7616d2d60b86f704a47#egg=niworkflows',
+    '0c09ee3d430875b86e670951575d29372812a213#egg=niworkflows',
 ]
 
 TESTS_REQUIRES = [

--- a/smriprep/__about__.py
+++ b/smriprep/__about__.py
@@ -18,7 +18,6 @@ __maintainer__ = 'Oscar Esteban'
 __email__ = 'code@oscaresteban.es'
 __status__ = 'Prototype'
 __url__ = 'https://github.com/poldracklab/smriprep'
-__package__ = 'smriprep'
 __description__ = ("sMRIPrep (Structural MRI PREprocessing) pipeline")
 __longdesc__ = """\
 The workflow is based on `Nipype <https://nipype.readthedocs.io>`_ and encompases a large
@@ -61,7 +60,7 @@ REQUIRES = [
 
 LINKS_REQUIRES = [
     'git+https://github.com/oesteban/niworkflows.git@'
-    '39928d76413e9d9d2c0e2286584d930bb3566c9a#egg=niworkflows',
+    'c769ec5e03e717650565da93f13c96032598202a#egg=niworkflows',
 ]
 
 TESTS_REQUIRES = [

--- a/smriprep/__about__.py
+++ b/smriprep/__about__.py
@@ -60,8 +60,8 @@ REQUIRES = [
 
 
 LINKS_REQUIRES = [
-    'git+https://github.com/poldracklab/niworkflows.git@'
-    '0c09ee3d430875b86e670951575d29372812a213#egg=niworkflows',
+    'git+https://github.com/oesteban/niworkflows.git@'
+    '39928d76413e9d9d2c0e2286584d930bb3566c9a#egg=niworkflows',
 ]
 
 TESTS_REQUIRES = [
@@ -83,7 +83,6 @@ EXTRA_REQUIRES = {
     'duecredit': ['duecredit'],
     'datalad': ['datalad'],
     'resmon': ['psutil>=5.4.0'],
-    'sentry': ['sentry-sdk>=0.5.3'],
 }
 EXTRA_REQUIRES['docs'] = EXTRA_REQUIRES['doc']
 

--- a/smriprep/cli/run.py
+++ b/smriprep/cli/run.py
@@ -261,13 +261,12 @@ def build_opts(opts):
                       str(Path(output_dir) / 'smriprep' / 'desc-aparcaseg_dseg.tsv'))
         logger.log(25, 'sMRIPrep finished without errors')
     finally:
-        from pkg_resources import resource_filename as pkgrf
         from niworkflows.viz.reports import generate_reports
 
         from ..utils.bids import write_derivative_description
         # Generate reports phase
         errno += generate_reports(subject_list, output_dir, work_dir, run_uuid,
-                                  config=pkgrf('smriprep', 'data/reports/config.json'))
+                                  packagename='smriprep')
         write_derivative_description(bids_dir, str(Path(output_dir) / 'smriprep'))
     sys.exit(int(errno > 0))
 

--- a/smriprep/cli/run.py
+++ b/smriprep/cli/run.py
@@ -53,9 +53,6 @@ def get_parser():
     parser.add_argument('--version', action='version', version='smriprep v{}'.format(__version__))
 
     g_bids = parser.add_argument_group('Options for filtering BIDS queries')
-    g_bids.add_argument('--skip-bids-validation', '--skip_bids_validation', action='store_true',
-                        default=False,
-                        help='assume the input dataset is BIDS compliant and skip the validation')
     g_bids.add_argument('--participant-label', '--participant_label', action='store', nargs='+',
                         help='a space delimited list of participant identifiers or a single '
                              'identifier (the sub- prefix can be removed)')
@@ -262,8 +259,9 @@ def build_opts(opts):
         logger.log(25, 'sMRIPrep finished without errors')
     finally:
         from niworkflows.viz.reports import generate_reports
-
         from ..utils.bids import write_derivative_description
+
+        logger.log(25, 'Writing reports for participants: %s', ', '.join(subject_list))
         # Generate reports phase
         errno += generate_reports(subject_list, output_dir, work_dir, run_uuid,
                                   packagename='smriprep')

--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -278,12 +278,17 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823,
                               ('probability_maps', 't1_tpms')]),
     ])
 
+    seg_rpt = pe.Node(ROIsPlot(colors=['magenta', 'b'], levels=[1.5, 2.5]),
+                      name='seg_rpt')
+
+    vol_spaces = [k for k in output_spaces.keys()
+                  if not k.startswith('fs')]
     # 6. Spatial normalization
-    anat_norm_wf, template = init_anat_norm_wf(
+    anat_norm_wf = init_anat_norm_wf(
         debug=debug,
         omp_nthreads=omp_nthreads,
         reportlets_dir=reportlets_dir,
-        template_spec=list(output_spaces.keys())[0])
+        template_list=vol_spaces)
     workflow.connect([
         (inputnode, anat_norm_wf, [
             (('t1w', fix_multi_T1w_source_name), 'inputnode.orig_t1w'),
@@ -303,9 +308,6 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823,
             ('outputnode.tpl_seg', 'tpl_seg'),
             ('outputnode.tpl_tpms', 'tpl_tpms')]),
     ])
-
-    seg_rpt = pe.Node(ROIsPlot(colors=['magenta', 'b'], levels=[1.5, 2.5]),
-                      name='seg_rpt')
     anat_reports_wf = init_anat_reports_wf(
         reportlets_dir=reportlets_dir, freesurfer=freesurfer)
     workflow.connect([
@@ -329,13 +331,14 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823,
     anat_derivatives_wf = init_anat_derivatives_wf(
         bids_root=bids_root,
         freesurfer=freesurfer,
-        template=template,
         output_dir=output_dir,
     )
 
     workflow.connect([
         (anat_template_wf, anat_derivatives_wf, [
             ('outputnode.t1w_valid_list', 'inputnode.source_files')]),
+        (anat_norm_wf, anat_derivatives_wf, [
+            ('outputnode.template', 'inputnode.template')]),
         (outputnode, anat_derivatives_wf, [
             ('warped', 'inputnode.t1_2_tpl'),
             ('forward_transform', 'inputnode.t1_2_tpl_forward_transform'),

--- a/smriprep/workflows/base.py
+++ b/smriprep/workflows/base.py
@@ -311,7 +311,7 @@ to workflows in *sMRIPrep*'s documentation]\
 
     ds_report_about = pe.Node(
         DerivativesDataSink(base_directory=reportlets_dir,
-                            suffix='about'),
+                            desc='about', keep_dtype=True),
         name='ds_report_about', run_without_submitting=True)
 
     # Preprocessing of T1w (includes registration to MNI)

--- a/smriprep/workflows/base.py
+++ b/smriprep/workflows/base.py
@@ -306,7 +306,7 @@ to workflows in *sMRIPrep*'s documentation]\
 
     ds_report_summary = pe.Node(
         DerivativesDataSink(base_directory=reportlets_dir,
-                            suffix='summary'),
+                            desc='summary', keep_dtype=True),
         name='ds_report_summary', run_without_submitting=True)
 
     ds_report_about = pe.Node(

--- a/smriprep/workflows/norm.py
+++ b/smriprep/workflows/norm.py
@@ -7,12 +7,13 @@ Spatial normalization workflows
 .. autofunction:: init_anat_norm_wf
 
 """
+from collections import defaultdict
 from nipype.pipeline import engine as pe
 from nipype.interfaces import utility as niu
 
 from nipype.interfaces.ants.base import Info as ANTsInfo
 
-from templateflow.api import get as get_template, get_metadata, templates
+from templateflow.api import get_metadata, templates
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 from niworkflows.interfaces.registration import RobustMNINormalizationRPT
 from niworkflows.interfaces.fixes import FixHeaderApplyTransforms as ApplyTransforms
@@ -23,7 +24,7 @@ def init_anat_norm_wf(
     debug,
     omp_nthreads,
     reportlets_dir,
-    template_spec,
+    template_list,
 ):
     """
     An individual spatial normalization workflow using ``antsRegistration``.
@@ -38,43 +39,57 @@ def init_anat_norm_wf(
         )
 
     """
-    template = template_spec.split(':')[0]
-    templateflow = template in templates()
 
-    if not templateflow:
+    templateflow = templates()
+    if any(template not in templateflow for template in template_list):
         raise NotImplementedError(
             'This is embarrassing - custom templates are not (yet) supported.'
             'Please make sure none of the options already available via TemplateFlow '
             'fit your needs.')
 
-    template_meta = get_metadata(template)
-    template_refs = ['@%s' % template.lower()]
+    workflow = Workflow('anat_norm_wf')
 
-    if template_meta.get('RRID', None):
-        template_refs += ['RRID:%s' % template_meta['RRID']]
-
-    workflow = Workflow('anat_norm_wf_%s' % template)
     workflow.__desc__ = """\
-Spatial normalization to the *{template_name}* [{template_refs};
-TemplateFlow ID: {template}] was performed through nonlinear
-registration with `antsRegistration` (ANTs {ants_ver}), using
-brain-extracted versions of both T1w reference and the T1w template.
+Volume-based spatial normalization to {targets} ({targets_id}) was performed through
+nonlinear registration with `antsRegistration` (ANTs {ants_ver}),
+using brain-extracted versions of both T1w reference and the T1w template.
+The following template{tpls} selected for spatial normalization:
 """.format(
         ants_ver=ANTsInfo.version() or '(version unknown)',
-        template=template,
-        template_name=template_meta['Name'],
-        template_refs=', '.join(template_refs),
+        targets='%s standard space%s' % (defaultdict(
+            'several'.format, {1: 'one', 2: 'two', 3: 'three', 4: 'four'})[len(template_list)],
+            's' * (len(template_list) != 1)),
+        targets_id=', '.join(template_list),
+        tpls=(' was', 's were')[len(template_list) != 1]
     )
+
+    # Append template citations to description
+    for template in template_list:
+        template_meta = get_metadata(template)
+        template_refs = ['@%s' % template.lower()]
+
+        if template_meta.get('RRID', None):
+            template_refs += ['RRID:%s' % template_meta['RRID']]
+
+        workflow.__desc__ += """\
+*{template_name}* [{template_refs}; TemplateFlow ID: {template}]""".format(
+            template=template,
+            template_name=template_meta['Name'],
+            template_refs=', '.join(template_refs))
+        workflow.__desc__ += (', ', '.')[template == template_list[-1]]
 
     inputnode = pe.Node(niu.IdentityInterface(fields=[
         'moving_image', 'moving_mask', 'moving_segmentation', 'moving_tpms',
-        'lesion_mask', 'orig_t1w']),
+        'lesion_mask', 'orig_t1w', 'template']),
         name='inputnode')
+    inputnode.iterables = [('template', template_list)]
     outputnode = pe.Node(niu.IdentityInterface(
         fields=['warped', 'forward_transform', 'reverse_transform',
                 'tpl_mask', 'tpl_seg', 'tpl_tpms', 'template']),
         name='outputnode')
-    outputnode.inputs.template = template
+
+    fixed_tpl = pe.Node(niu.Function(function=_templateflow_ds),
+                        name='fixed_tpl', run_without_submitting=True)
 
     registration = pe.Node(RobustMNINormalizationRPT(
         float=True, generate_report=True,
@@ -92,21 +107,17 @@ brain-extracted versions of both T1w reference and the T1w template.
                                           interpolation='BSpline'),
                           iterfield=['input_image'], name='tpl_tpms')
 
-    # TODO isolate the spatial normalization workflow #############
-    ref_img = str(get_template(template, resolution=1, desc=None, suffix='T1w',
-                               extensions=['.nii', '.nii.gz']))
-
-    registration.inputs.template = template
-    tpl_mask.inputs.reference_image = ref_img
-    tpl_seg.inputs.reference_image = ref_img
-    tpl_tpms.inputs.reference_image = ref_img
-
     workflow.connect([
+        (inputnode, fixed_tpl, [('template', 'template')]),
+        (inputnode, registration, [('template', 'template')]),
         (inputnode, registration, [
             ('moving_image', 'moving_image'),
             ('moving_mask', 'moving_mask'),
             ('lesion_mask', 'lesion_mask')]),
         (inputnode, tpl_mask, [('moving_mask', 'input_image')]),
+        (fixed_tpl, tpl_mask, [('out', 'reference_image')]),
+        (fixed_tpl, tpl_seg, [('out', 'reference_image')]),
+        (fixed_tpl, tpl_tpms, [('out', 'reference_image')]),
         (registration, tpl_mask, [('composite_transform', 'transforms')]),
         (inputnode, tpl_seg, [('moving_segmentation', 'input_image')]),
         (registration, tpl_seg, [('composite_transform', 'transforms')]),
@@ -119,17 +130,26 @@ brain-extracted versions of both T1w reference and the T1w template.
         (tpl_mask, outputnode, [('output_image', 'tpl_mask')]),
         (tpl_seg, outputnode, [('output_image', 'tpl_seg')]),
         (tpl_tpms, outputnode, [('output_image', 'tpl_tpms')]),
+        (inputnode, outputnode, [('template', 'template')]),
     ])
 
     # Store report
     ds_t1_2_tpl_report = pe.Node(
-        DerivativesDataSink(base_directory=reportlets_dir, space=template,
+        DerivativesDataSink(base_directory=reportlets_dir,
                             suffix='t1w'),
         name='ds_t1_2_tpl_report', run_without_submitting=True)
 
     workflow.connect([
-        (inputnode, ds_t1_2_tpl_report, [('orig_t1w', 'source_file')]),
+        (inputnode, ds_t1_2_tpl_report, [
+            ('template', 'space'),
+            ('orig_t1w', 'source_file')]),
         (registration, ds_t1_2_tpl_report, [('out_report', 'in_file')]),
     ])
+    return workflow
 
-    return workflow, template
+
+def _templateflow_ds(template, resolution=1, desc=None, suffix='T1w',
+                     extensions=('.nii', '.nii.gz')):
+    from templateflow.api import get as get_template
+    return str(get_template(template, resolution=resolution, desc=desc,
+                            suffix=suffix, extensions=extensions))

--- a/smriprep/workflows/norm.py
+++ b/smriprep/workflows/norm.py
@@ -193,8 +193,7 @@ The following template{tpls} selected for spatial normalization:
 
     # Store report
     ds_t1_2_tpl_report = pe.Node(
-        DerivativesDataSink(base_directory=reportlets_dir,
-                            suffix='t1w'),
+        DerivativesDataSink(base_directory=reportlets_dir, keep_dtype=True),
         name='ds_t1_2_tpl_report', run_without_submitting=True)
 
     workflow.connect([

--- a/smriprep/workflows/outputs.py
+++ b/smriprep/workflows/outputs.py
@@ -124,26 +124,28 @@ def init_anat_derivatives_wf(bids_root, freesurfer, output_dir,
 
     # Transforms
     ds_t1_tpl_inv_warp = pe.Node(
-        DerivativesDataSink(allowed_entities=['from', 'to'], base_directory=output_dir,
-                            to='T1w', mode='image', suffix='mode-image_xfm'),
+        DerivativesDataSink(base_directory=output_dir, allowed_entities=['from', 'to', 'mode'],
+                            to='T1w', mode='image', suffix='xfm'),
         name='ds_t1_tpl_inv_warp', run_without_submitting=True)
 
+    # Please note the dictionary unpacking to provide the from argument.
+    # It is necessary because from is a protected keyword (not allowed as argument name).
     ds_t1_template_transforms = pe.MapNode(
-        DerivativesDataSink(allowed_entities=['from', 'to'], base_directory=output_dir,
-                            to='T1w', suffix='mode-image_xfm', **{'from': 'orig'}),
+        DerivativesDataSink(base_directory=output_dir, allowed_entities=['from', 'to', 'mode'],
+                            to='T1w', mode='image', suffix='xfm', **{'from': 'orig'}),
         iterfield=['source_file', 'in_file'],
         name='ds_t1_template_transforms', run_without_submitting=True)
 
     ds_t1_tpl_warp = pe.Node(
-        DerivativesDataSink(allowed_entities=['from', 'to'], base_directory=output_dir,
-                            suffix='mode-image_xfm', **{'from': 'T1w'}),
+        DerivativesDataSink(base_directory=output_dir, allowed_entities=['from', 'to', 'mode'],
+                            mode='image', suffix='xfm', **{'from': 'T1w'}),
         name='ds_t1_tpl_warp', run_without_submitting=True)
 
     lta_2_itk = pe.Node(LTAConvert(out_itk=True), name='lta_2_itk')
 
     ds_t1_fsnative = pe.Node(
-        DerivativesDataSink(allowed_entities=['from', 'to'], base_directory=output_dir,
-                            suffix='mode-image_xfm', **{'from': 'T1w', 'to': 'fsnative'}),
+        DerivativesDataSink(base_directory=output_dir, allowed_entities=['from', 'to', 'mode'],
+                            mode='image', to='fsnative', suffix='xfm', **{'from': 'T1w'}),
         name='ds_t1_fsnative', run_without_submitting=True)
 
     name_surfs = pe.MapNode(GiftiNameSource(pattern=r'(?P<LR>[lr])h.(?P<surf>.+)_converted.gii',


### PR DESCRIPTION
This PR makes more flexible the spatial normalization, setting a list of target templates as an iterable for the new spatial normalization workflow (#72).

This PR also makes use of the refactored reports of poldracklab/niworkflows#344, which allow rendering several spatial normalization reportlets. To do so, the nomenclature of reportlets has been adapted and resembles a BIDS-like organization.