### PR TITLE
FIX: resolve behavior when deprecated ``--template`` is given

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -417,7 +417,7 @@ jobs:
                 poldracklab/smriprep:latest \
                 /tmp/data/ds054 /tmp/ds054/derivatives participant \
                 -w /tmp/ds054/work --fs-no-reconall --sloppy --write-graph \
-                --output_spaces MNI152Lin MNI152NLin2009c \
+                --output-spaces MNI152Lin MNI152NLin2009cAsym \
                 --mem-gb 4 --ncpus 2 --omp-nthreads 2 -vv \
                 --fs-license-file /tmp/fslicense/license.txt
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -417,7 +417,8 @@ jobs:
                 poldracklab/smriprep:latest \
                 /tmp/data/ds054 /tmp/ds054/derivatives participant \
                 -w /tmp/ds054/work --fs-no-reconall --sloppy --write-graph \
-                --template MNI152Lin --mem-gb 4 --ncpus 2 --omp-nthreads 2 -vv \
+                --output_spaces MNI152Lin MNI152NLin2009c \
+                --mem-gb 4 --ncpus 2 --omp-nthreads 2 -vv \
                 --fs-license-file /tmp/fslicense/license.txt
       - save_cache:
          key: ds054-anat-v3-{{ .Branch }}-{{ epoch }}

--- a/smriprep/cli/run.py
+++ b/smriprep/cli/run.py
@@ -26,7 +26,6 @@ def check_deps(workflow):
 def get_parser():
     """Build parser object"""
     from pathlib import Path
-    from collections import OrderedDict
     from argparse import ArgumentParser
     from argparse import RawTextHelpFormatter
     from templateflow.api import templates


### PR DESCRIPTION
Before this change, when ``--template`` was set, sMRIPrep would not
check whether ``--output-spaces`` was also specified too. As a result,
instead of replacing the default ``MNI152NLin2009cAsym`` template, the
new identifier given with ``--template`` was inserted at the front of
the spaces.

In other words:
```
smriprep ... --output-spaces MNI152NLin2009cAsym --template MNI152Lin
```
and
```
smriprep ... --template MNI152Lin
```
would both end up understanding ``['MNI152Lin', 'MNI152NLin2009cAsym']``,
whereas with the original behaviour, one would expect to only have
``['MNI152Lin']`` when using the second command.

This PR addresses such issue (and updates the CircleCI test not to use
``--template`` as I have checked locally this works as expected).