### PR TITLE
FIX: Keep header consistency along anatomical workflow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 indexed_gzip>=0.8.8
 nilearn!=0.5.0,!=0.5.1
-git+https://github.com/poldracklab/niworkflows.git@fe6f301fcffb6397eefb4d268b19586c8ff2c951#egg=niworkflows
+niworkflows<0.10.0a0,>=0.9.2
 templateflow<0.2.0a0,>=0.1.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 indexed_gzip>=0.8.8
 nilearn!=0.5.0,!=0.5.1
-niworkflows<0.10.0a0,>=0.9.0
+git+https://github.com/oesteban/niworkflows.git@5bdb7ef826534150f61326dd422285e8310bf781#egg=niworkflows
 templateflow<0.2.0a0,>=0.1.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 indexed_gzip>=0.8.8
 nilearn!=0.5.0,!=0.5.1
-git+https://github.com/oesteban/niworkflows.git@ff46cb11f27e7b8f9033087ffd291e0b90651b49#egg=niworkflows
+git+https://github.com/oesteban/niworkflows.git@9c225461c5b2929df6fce7647ed8bc34b42c7fd0#egg=niworkflows
 templateflow<0.2.0a0,>=0.1.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 indexed_gzip>=0.8.8
 nilearn!=0.5.0,!=0.5.1
-git+https://github.com/oesteban/niworkflows.git@5bdb7ef826534150f61326dd422285e8310bf781#egg=niworkflows
+git+https://github.com/oesteban/niworkflows.git@ff46cb11f27e7b8f9033087ffd291e0b90651b49#egg=niworkflows
 templateflow<0.2.0a0,>=0.1.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 indexed_gzip>=0.8.8
 nilearn!=0.5.0,!=0.5.1
-git+https://github.com/oesteban/niworkflows.git@9c225461c5b2929df6fce7647ed8bc34b42c7fd0#egg=niworkflows
+git+https://github.com/poldracklab/niworkflows.git@fe6f301fcffb6397eefb4d268b19586c8ff2c951#egg=niworkflows
 templateflow<0.2.0a0,>=0.1.7

--- a/smriprep/__about__.py
+++ b/smriprep/__about__.py
@@ -59,7 +59,7 @@ REQUIRES = [
 
 LINKS_REQUIRES = [
     'git+https://github.com/oesteban/niworkflows.git@'
-    '5bdb7ef826534150f61326dd422285e8310bf781#egg=niworkflows',
+    'ff46cb11f27e7b8f9033087ffd291e0b90651b49#egg=niworkflows',
 ]
 
 TESTS_REQUIRES = [

--- a/smriprep/__about__.py
+++ b/smriprep/__about__.py
@@ -48,7 +48,7 @@ REQUIRES = [
     'matplotlib>=2.2.0',
     'nibabel>=2.2.1',
     'nipype>=1.1.6',
-    'niworkflows',
+    'niworkflows<0.10.0a0,>=0.9.2',
     'numpy',
     'packaging',
     'pybids',
@@ -58,8 +58,6 @@ REQUIRES = [
 
 
 LINKS_REQUIRES = [
-    'git+https://github.com/poldracklab/niworkflows.git@'
-    'fe6f301fcffb6397eefb4d268b19586c8ff2c951#egg=niworkflows',
 ]
 
 TESTS_REQUIRES = [

--- a/smriprep/__about__.py
+++ b/smriprep/__about__.py
@@ -48,7 +48,7 @@ REQUIRES = [
     'matplotlib>=2.2.0',
     'nibabel>=2.2.1',
     'nipype>=1.1.6',
-    'niworkflows<0.10.0a0,>=0.9.0',
+    'niworkflows',
     'numpy',
     'packaging',
     'pybids',
@@ -58,6 +58,8 @@ REQUIRES = [
 
 
 LINKS_REQUIRES = [
+    'git+https://github.com/oesteban/niworkflows.git@'
+    '5bdb7ef826534150f61326dd422285e8310bf781#egg=niworkflows',
 ]
 
 TESTS_REQUIRES = [

--- a/smriprep/__about__.py
+++ b/smriprep/__about__.py
@@ -58,8 +58,8 @@ REQUIRES = [
 
 
 LINKS_REQUIRES = [
-    'git+https://github.com/oesteban/niworkflows.git@'
-    '9c225461c5b2929df6fce7647ed8bc34b42c7fd0#egg=niworkflows',
+    'git+https://github.com/poldracklab/niworkflows.git@'
+    'fe6f301fcffb6397eefb4d268b19586c8ff2c951#egg=niworkflows',
 ]
 
 TESTS_REQUIRES = [

--- a/smriprep/__about__.py
+++ b/smriprep/__about__.py
@@ -59,7 +59,7 @@ REQUIRES = [
 
 LINKS_REQUIRES = [
     'git+https://github.com/oesteban/niworkflows.git@'
-    'ff46cb11f27e7b8f9033087ffd291e0b90651b49#egg=niworkflows',
+    '9c225461c5b2929df6fce7647ed8bc34b42c7fd0#egg=niworkflows',
 ]
 
 TESTS_REQUIRES = [


### PR DESCRIPTION
This PR inserts a validation node right after creating the anatomical
template and pins niworkflows to use a revised version of the
antsBrainExtraction workflow that controls consistency of headers.

Fixes #82. Required by poldracklab/fmriprep#1615.