### PR TITLE
ENH: Use proper resolution in anatomical outputs

### DIFF
--- a/smriprep/workflows/norm.py
+++ b/smriprep/workflows/norm.py
@@ -156,10 +156,13 @@ The following template{tpls} selected for spatial normalization:
                   'tpl_mask', 'tpl_seg', 'tpl_tpms', 'template']
     poutputnode = pe.Node(niu.IdentityInterface(fields=out_fields), name='poutputnode')
 
-    tpl_specs = pe.Node(niu.Function(function=_select_specs),
-                        name='tpl_specs', run_without_submitting=True)
+    tpl_specs = pe.Node(niu.Function(
+        function=_select_specs,
+        input_names=['template_list', 'template_specs', 'force_res']),
+        name='tpl_specs', run_without_submitting=True)
     tpl_specs.inputs.template_list = template_list
     tpl_specs.inputs.template_specs = template_specs
+    tpl_specs.inputs.force_res = 1
 
     tpl_select = pe.Node(niu.Function(function=_get_template),
                          name='tpl_select', run_without_submitting=True)
@@ -281,8 +284,14 @@ def _rpt_masks(mask_file, before, after, after_mask=None):
     return abspath('before.nii.gz'), abspath('after.nii.gz')
 
 
-def _select_specs(template, template_list, template_specs):
-    return template_specs[template_list.index(template)]
+def _select_specs(template, template_list, template_specs, force_res=None):
+    out_spec = template_specs[template_list.index(template)]
+    if force_res is not None:
+        out_spec.pop('res', None)
+        out_spec.pop('resoluton', None)
+        out_spec['res'] = force_res
+
+    return out_spec
 
 
 def _get_template(template, template_spec, suffix='T1w', desc=None):

--- a/smriprep/workflows/norm.py
+++ b/smriprep/workflows/norm.py
@@ -158,7 +158,7 @@ The following template{tpls} selected for spatial normalization:
 
     tpl_specs = pe.Node(niu.Function(
         function=_select_specs,
-        input_names=['template_list', 'template_specs', 'force_res']),
+        input_names=['template', 'template_list', 'template_specs', 'force_res']),
         name='tpl_specs', run_without_submitting=True)
     tpl_specs.inputs.template_list = template_list
     tpl_specs.inputs.template_specs = template_specs


### PR DESCRIPTION
Although spatial normalization of the T1w image was being done using
resolution-1 of the template, subsequent reportlet generation and
resampling for preservation under ``anat/`` would follow whatever
res-X modified given within ``--output-spaces``.

Since the ``--output-spaces`` argument is thought to mandate over
BOLD outputs only, the previous implementation was a problem as it
imposed a lower resolution when it wasn't really appropriate.

This PR will generate high-resolution preprocessed anatomicals
(reportlet and derivative) in any case.

Spatial normalization will keep working the same way (i.e., it will
use res-1, except if `--sloppy` was given in which case it will use
res-2).