### PR TITLE
ENH: Reduce friction when iterating over target templates

### DIFF
--- a/smriprep/interfaces/templateflow.py
+++ b/smriprep/interfaces/templateflow.py
@@ -1,0 +1,69 @@
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+"""Interfaces to get templates from TemplateFlow."""
+from templateflow import api as tf
+from nipype.interfaces.base import (
+    SimpleInterface, BaseInterfaceInputSpec, TraitedSpec,
+    isdefined, traits, File, InputMultiObject,
+)
+
+
+class _TemplateFlowSelectInputSpec(BaseInterfaceInputSpec):
+    template = traits.Enum(*tf.templates(), mandatory=True,
+                           desc='Template ID')
+    atlas = InputMultiObject(traits.Str, desc='Specify an atlas')
+    resolution = InputMultiObject(traits.Int, desc='Specify a template resolution index')
+    template_spec = traits.DictStrAny(
+        {'atlas': None}, usedefault=True, desc='Template specifications')
+
+
+class _TemplateFlowSelectOutputSpec(TraitedSpec):
+    t1w_file = File(exists=True, desc='T1w template')
+    brain_mask = File(exists=True, desc="Template's brain mask")
+
+
+class TemplateFlowSelect(SimpleInterface):
+    """
+    Select TemplateFlow elements.
+
+    >>> select = TemplateFlowSelect(resolution=1)
+    >>> select.inputs.template = 'MNI152NLin2009cAsym'
+    >>> result = select.run()
+    >>> result.outputs.t1w_file  # doctest: +ELLIPSIS
+    '.../tpl-MNI152NLin2009cAsym_res-01_T1w.nii.gz'
+
+    >>> result.outputs.brain_mask  # doctest: +ELLIPSIS
+    '.../tpl-MNI152NLin2009cAsym_res-01_desc-brain_mask.nii.gz'
+
+    >>> select = TemplateFlowSelect(resolution=1)
+    >>> select.inputs.template = 'MNIPediatricAsym'
+    >>> select.inputs.template_spec = {'cohort': 5, 'resolution': 1}
+    >>> result = select.run()
+    >>> result.outputs.t1w_file  # doctest: +ELLIPSIS
+    '.../tpl-MNIPediatricAsym_cohort-5_res-1_T1w.nii.gz'
+
+    """
+
+    input_spec = _TemplateFlowSelectInputSpec
+    output_spec = _TemplateFlowSelectOutputSpec
+
+    def _run_interface(self, runtime):
+        specs = self.inputs.template_spec
+        if isdefined(self.inputs.resolution):
+            specs['resolution'] = self.inputs.resolution
+        if isdefined(self.inputs.atlas):
+            specs['atlas'] = self.inputs.atlas
+        self._results['t1w_file'] = tf.get(
+            self.inputs.template,
+            desc=None,
+            suffix='T1w',
+            **specs
+        )
+
+        self._results['brain_mask'] = tf.get(
+            self.inputs.template,
+            desc='brain',
+            suffix='mask',
+            **specs
+        )
+        return runtime

--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -251,8 +251,8 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823,
         debug=debug,
         omp_nthreads=omp_nthreads,
         reportlets_dir=reportlets_dir,
-        template_list=vol_spaces,
-        template_specs=[output_spaces[k] for k in vol_spaces])
+        templates=[(v, output_spaces[v]) for v in vol_spaces],
+    )
 
     workflow.connect([
         # Step 1.

--- a/smriprep/workflows/norm.py
+++ b/smriprep/workflows/norm.py
@@ -143,7 +143,7 @@ The following template{tpls} selected for spatial normalization:
                   'std_mask', 'std_dseg', 'std_tpms', 'template']
     poutputnode = pe.Node(niu.IdentityInterface(fields=out_fields), name='poutputnode')
 
-    tf_select = pe.Node(TemplateFlowSelect(resolution=1),
+    tf_select = pe.Node(TemplateFlowSelect(resolution=1 + debug),
                         name='tf_select', run_without_submitting=True)
 
     # With the improvements from poldracklab/niworkflows#342 this truncation is now necessary

--- a/smriprep/workflows/norm.py
+++ b/smriprep/workflows/norm.py
@@ -12,21 +12,21 @@ from nipype.interfaces import utility as niu
 
 from nipype.interfaces.ants.base import Info as ANTsInfo
 
-from templateflow.api import get_metadata, templates
+from templateflow.api import get_metadata, templates as get_templates
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 from niworkflows.interfaces.ants import ImageMath
 from niworkflows.interfaces.mni import RobustMNINormalization
 from niworkflows.interfaces.fixes import FixHeaderApplyTransforms as ApplyTransforms
 from niworkflows.interfaces import SimpleBeforeAfter
 from ..interfaces import DerivativesDataSink
+from ..interfaces.templateflow import TemplateFlowSelect
 
 
 def init_anat_norm_wf(
     debug,
     omp_nthreads,
     reportlets_dir,
-    template_list,
-    template_specs=None,
+    templates,
 ):
     """
     Build an individual spatial normalization workflow using ``antsRegistration``.
@@ -52,11 +52,10 @@ def init_anat_norm_wf(
             Maximum number of threads an individual process may use.
         reportlets_dir : str
             Directory in which to save reportlets.
-        template_list : list of str
-            List of TemplateFlow identifiers (e.g. ``MNI152NLin6Asym``) that
-            specifies the target template for spatial normalization. In the
-            future, this parameter should accept also paths to custom/private
-            templates with TemplateFlow's organization.
+        templates : list of tuples
+            List of tuples containing TemplateFlow identifiers (e.g. ``MNI152NLin6Asym``)
+            and corresponding specs, which specify target templates
+            for spatial normalization.
 
     **Inputs**
 
@@ -97,18 +96,15 @@ def init_anat_norm_wf(
             workflow.
 
     """
-    if not isinstance(template_list, (list, tuple)):
-        template_list = [template_list]
-
-    templateflow = templates()
-    missing_tpls = [template for template in template_list if template not in templateflow]
+    templateflow = get_templates()
+    missing_tpls = [template for template, _ in templates if template not in templateflow]
     if missing_tpls:
         raise ValueError("""\
 One or more templates were not found (%s). Please make sure TemplateFlow is \
 correctly installed and contains the given template identifiers.""" % ', '.join(missing_tpls))
 
+    ntpls = len(templates)
     workflow = Workflow('anat_norm_wf')
-
     workflow.__desc__ = """\
 Volume-based spatial normalization to {targets} ({targets_id}) was performed through
 nonlinear registration with `antsRegistration` (ANTs {ants_ver}),
@@ -117,21 +113,14 @@ The following template{tpls} selected for spatial normalization:
 """.format(
         ants_ver=ANTsInfo.version() or '(version unknown)',
         targets='%s standard space%s' % (defaultdict(
-            'several'.format, {1: 'one', 2: 'two', 3: 'three', 4: 'four'})[len(template_list)],
-            's' * (len(template_list) != 1)),
-        targets_id=', '.join(template_list),
-        tpls=(' was', 's were')[len(template_list) != 1]
+            'several'.format, {1: 'one', 2: 'two', 3: 'three', 4: 'four'})[ntpls],
+            's' * (ntpls != 1)),
+        targets_id=', '.join((t for t, _ in templates)),
+        tpls=(' was', 's were')[ntpls != 1]
     )
 
-    if not template_specs:
-        template_specs = [{}] * len(template_list)
-
-    if len(template_list) != len(template_specs):
-        raise RuntimeError('Number of templates (%d) doesn\'t match the number of specs '
-                           '(%d) provided.' % (len(template_list), len(template_specs)))
-
     # Append template citations to description
-    for template in template_list:
+    for template, _ in templates:
         template_meta = get_metadata(template)
         template_refs = ['@%s' % template.lower()]
 
@@ -143,27 +132,19 @@ The following template{tpls} selected for spatial normalization:
             template=template,
             template_name=template_meta['Name'],
             template_refs=', '.join(template_refs))
-        workflow.__desc__ += (', ', '.')[template == template_list[-1]]
+        workflow.__desc__ += (', ', '.')[template == templates[-1][0]]
 
     inputnode = pe.Node(niu.IdentityInterface(fields=[
         'moving_image', 'moving_mask', 'moving_segmentation', 'moving_tpms',
         'lesion_mask', 'orig_t1w', 'template']),
         name='inputnode')
-    inputnode.iterables = [('template', template_list)]
+    inputnode.iterables = [('template', templates)]
     out_fields = ['standardized', 'anat2std_xfm', 'std2anat_xfm',
                   'std_mask', 'std_dseg', 'std_tpms', 'template']
     poutputnode = pe.Node(niu.IdentityInterface(fields=out_fields), name='poutputnode')
 
-    tpl_specs = pe.Node(niu.Function(
-        function=_select_specs,
-        input_names=['template', 'template_list', 'template_specs', 'force_res']),
-        name='tpl_specs', run_without_submitting=True)
-    tpl_specs.inputs.template_list = template_list
-    tpl_specs.inputs.template_specs = template_specs
-    tpl_specs.inputs.force_res = 1
-
-    tpl_select = pe.Node(niu.Function(function=_get_template),
-                         name='tpl_select', run_without_submitting=True)
+    tf_select = pe.Node(TemplateFlowSelect(resolution=1),
+                        name='tf_select', run_without_submitting=True)
 
     # With the improvements from poldracklab/niworkflows#342 this truncation is now necessary
     trunc_mov = pe.Node(ImageMath(operation='TruncateImageIntensity', op2='0.01 0.999 256'),
@@ -188,21 +169,20 @@ The following template{tpls} selected for spatial normalization:
                           iterfield=['input_image'], name='std_tpms')
 
     workflow.connect([
-        (inputnode, tpl_specs, [('template', 'template')]),
-        (inputnode, tpl_select, [('template', 'template')]),
-        (inputnode, registration, [('template', 'template')]),
+        (inputnode, tf_select, [(('template', _get_name), 'template'),
+                                (('template', _get_spec), 'template_spec')]),
+        (inputnode, registration, [(('template', _get_name), 'template'),
+                                   (('template', _get_spec), 'template_spec')]),
         (inputnode, trunc_mov, [('moving_image', 'op1')]),
         (inputnode, registration, [
             ('moving_mask', 'moving_mask'),
             ('lesion_mask', 'lesion_mask')]),
         (inputnode, tpl_moving, [('moving_image', 'input_image')]),
         (inputnode, std_mask, [('moving_mask', 'input_image')]),
-        (tpl_specs, tpl_select, [('out', 'template_spec')]),
-        (tpl_specs, registration, [(('out', _drop_res), 'template_spec')]),
-        (tpl_select, tpl_moving, [('out', 'reference_image')]),
-        (tpl_select, std_mask, [('out', 'reference_image')]),
-        (tpl_select, std_dseg, [('out', 'reference_image')]),
-        (tpl_select, std_tpms, [('out', 'reference_image')]),
+        (tf_select, tpl_moving, [('t1w_file', 'reference_image')]),
+        (tf_select, std_mask, [('t1w_file', 'reference_image')]),
+        (tf_select, std_dseg, [('t1w_file', 'reference_image')]),
+        (tf_select, std_tpms, [('t1w_file', 'reference_image')]),
         (trunc_mov, registration, [
             ('output_image', 'moving_image')]),
         (registration, tpl_moving, [('composite_transform', 'transforms')]),
@@ -221,14 +201,6 @@ The following template{tpls} selected for spatial normalization:
         (inputnode, poutputnode, [('template', 'template')]),
     ])
 
-    # Generate and store report
-    msk_select = pe.Node(niu.Function(
-        function=_get_template,
-        input_names=['template', 'template_spec', 'suffix', 'desc']),
-        name='msk_select', run_without_submitting=True)
-    msk_select.inputs.desc = 'brain'
-    msk_select.inputs.suffix = 'mask'
-
     norm_msk = pe.Node(niu.Function(
         function=_rpt_masks, output_names=['before', 'after'],
         input_names=['mask_file', 'before', 'after', 'after_mask']),
@@ -241,17 +213,15 @@ The following template{tpls} selected for spatial normalization:
         name='ds_std_t1w_report', run_without_submitting=True)
 
     workflow.connect([
-        (inputnode, msk_select, [('template', 'template')]),
-        (inputnode, norm_rpt, [('template', 'before_label')]),
+        (inputnode, norm_rpt, [(('template', _get_name), 'before_label')]),
         (std_mask, norm_msk, [('output_image', 'after_mask')]),
-        (tpl_specs, msk_select, [('out', 'template_spec')]),
-        (msk_select, norm_msk, [('out', 'mask_file')]),
-        (tpl_select, norm_msk, [('out', 'before')]),
+        (tf_select, norm_msk, [('brain_mask', 'mask_file')]),
+        (tf_select, norm_msk, [('t1w_file', 'before')]),
         (tpl_moving, norm_msk, [('output_image', 'after')]),
         (norm_msk, norm_rpt, [('before', 'before'),
                               ('after', 'after')]),
         (inputnode, ds_std_t1w_report, [
-            ('template', 'space'),
+            (('template', _get_name), 'space'),
             ('orig_t1w', 'source_file')]),
         (norm_rpt, ds_std_t1w_report, [('out_report', 'in_file')]),
     ])
@@ -282,24 +252,9 @@ def _rpt_masks(mask_file, before, after, after_mask=None):
     return abspath('before.nii.gz'), abspath('after.nii.gz')
 
 
-def _select_specs(template, template_list, template_specs, force_res=None):
-    out_spec = template_specs[template_list.index(template)]
-    if force_res is not None:
-        out_spec.pop('res', None)
-        out_spec.pop('resoluton', None)
-        out_spec['res'] = force_res
-
-    return out_spec
+def _get_name(in_tuple):
+    return in_tuple[0]
 
 
-def _get_template(template, template_spec, suffix='T1w', desc=None):
-    from niworkflows.utils.misc import get_template_specs
-    template_spec['suffix'] = suffix
-    template_spec['desc'] = desc
-    return get_template_specs(template, template_spec=template_spec)[0]
-
-
-def _drop_res(in_dict):
-    in_dict.pop('res', None)
-    in_dict.pop('resoluton', None)
-    return in_dict
+def _get_spec(in_tuple):
+    return in_tuple[1]

--- a/smriprep/workflows/outputs.py
+++ b/smriprep/workflows/outputs.py
@@ -169,10 +169,10 @@ def init_anat_derivatives_wf(bids_root, freesurfer, num_t1w, output_dir,
         # Template
         (inputnode, ds_t1w_tpl_warp, [
             ('anat2std_xfm', 'in_file'),
-            ('template', 'to')]),
+            (('template', _get_name), 'to')]),
         (inputnode, ds_t1w_tpl_inv_warp, [
             ('std2anat_xfm', 'in_file'),
-            ('template', 'from')]),
+            (('template', _get_name), 'from')]),
         (inputnode, ds_t1w_tpl, [
             ('std_t1w', 'in_file'),
             (('template', _get_name), 'space')]),

--- a/smriprep/workflows/outputs.py
+++ b/smriprep/workflows/outputs.py
@@ -175,17 +175,17 @@ def init_anat_derivatives_wf(bids_root, freesurfer, num_t1w, output_dir,
             ('template', 'from')]),
         (inputnode, ds_t1w_tpl, [
             ('std_t1w', 'in_file'),
-            ('template', 'space')]),
+            (('template', _get_name), 'space')]),
         (inputnode, ds_std_mask, [
             ('std_mask', 'in_file'),
-            ('template', 'space'),
+            (('template', _get_name), 'space'),
             (('template', _rawsources), 'RawSources')]),
-        (inputnode, ds_std_dseg, [('template', 'space')]),
+        (inputnode, ds_std_dseg, [(('template', _get_name), 'space')]),
         (inputnode, lut_std_dseg, [('std_dseg', 'in_file')]),
         (lut_std_dseg, ds_std_dseg, [('out', 'in_file')]),
         (inputnode, ds_std_tpms, [
             ('std_tpms', 'in_file'),
-            ('template', 'space')]),
+            (('template', _get_name), 'space')]),
         (t1w_name, ds_t1w_tpl_warp, [('out', 'source_file')]),
         (t1w_name, ds_t1w_tpl_inv_warp, [('out', 'source_file')]),
         (t1w_name, ds_t1w_tpl, [('out', 'source_file')]),
@@ -257,4 +257,10 @@ def _bids_relative(in_files, bids_root):
 
 
 def _rawsources(template):
+    if isinstance(template, tuple):
+        template = template[0]
     return 'tpl-{0}/tpl-{0}_desc-brain_mask.nii.gz'.format(template)
+
+
+def _get_name(in_tuple):
+    return in_tuple[0]


### PR DESCRIPTION
Spatial normalization defines selected ``--output-spaces`` as an
iterable to the workflow.
This PR removes several ad-hoc function nodes and replaces them with a
new nipype interface to query templates.
These changes will facilitate concluding #107.