### PR TITLE
ENH: Decoupling anatomical reports

### DIFF
--- a/smriprep/interfaces/reports.py
+++ b/smriprep/interfaces/reports.py
@@ -1,13 +1,6 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
-"""
-Interfaces to generate reportlets
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-
-"""
+"""Interfaces to generate reportlets."""
 
 from pathlib import Path
 import time
@@ -17,6 +10,10 @@ from nipype.interfaces.base import (
     File, Directory, InputMultiObject, Str, isdefined,
     SimpleInterface)
 from nipype.interfaces import freesurfer as fs
+from nipype.interfaces.io import FSSourceInputSpec as _FSSourceInputSpec
+from nipype.interfaces.mixins import reporting
+
+from niworkflows.interfaces.report_base import SVGReportCapableInputSpec
 
 
 SUBJECT_TEMPLATE = """\
@@ -115,3 +112,46 @@ class AboutSummary(SummaryInterface):
         return ABOUT_TEMPLATE.format(version=self.inputs.version,
                                      command=self.inputs.command,
                                      date=time.strftime("%Y-%m-%d %H:%M:%S %z"))
+
+
+class _FSSurfaceReportInputSpec(SVGReportCapableInputSpec, _FSSourceInputSpec):
+    pass
+
+
+class _FSSurfaceReportOutputSpec(reporting.ReportCapableOutputSpec):
+    pass
+
+
+class FSSurfaceReport(SimpleInterface):
+    """Replaces ``ReconAllRPT``, without need of calling recon-all."""
+
+    input_spec = _FSSurfaceReportInputSpec
+    output_spec = _FSSurfaceReportOutputSpec
+
+    def _run_interface(self, runtime):
+        from niworkflows.viz.utils import plot_registration, cuts_from_bbox, compose_view
+        from nilearn.image import load_img
+
+        rootdir = Path(self.inputs.subjects_dir) / self.inputs.subject_id
+        _anat_file = str(rootdir / 'mri' / 'brain.mgz')
+        _contour_file = str(rootdir / 'mri' / 'ribbon.mgz')
+
+        anat = load_img(_anat_file)
+        contour_nii = load_img(_contour_file)
+
+        n_cuts = 7
+        cuts = cuts_from_bbox(contour_nii, cuts=n_cuts)
+
+        self._results['out_report'] = str(Path(runtime.cwd) / self.inputs.out_report)
+
+        # Call composer
+        compose_view(
+            plot_registration(anat, 'fixed-image',
+                              estimate_brightness=True,
+                              cuts=cuts,
+                              contour=contour_nii,
+                              compress=self.inputs.compress_report),
+            [],
+            out_file=self._results['out_report']
+        )
+        return runtime

--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -21,7 +21,6 @@ from nipype.interfaces.ants.base import Info as ANTsInfo
 from nipype.interfaces.ants import N4BiasFieldCorrection
 
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
-from niworkflows.interfaces.masks import ROIsPlot
 from niworkflows.interfaces.freesurfer import (
     StructuralReference,
     PatchedConcatenateLTA as ConcatenateLTA,
@@ -241,16 +240,12 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823,
                                 ('probability_maps', 't1w_tpms')]),
     ])
 
-    seg_rpt = pe.Node(ROIsPlot(colors=['magenta', 'b'], levels=[1.5, 2.5]),
-                      name='seg_rpt')
-
     # 4. Spatial normalization
     vol_spaces = [k for k in output_spaces.keys()
                   if not k.startswith('fs')]
     anat_norm_wf = init_anat_norm_wf(
         debug=debug,
         omp_nthreads=omp_nthreads,
-        reportlets_dir=reportlets_dir,
         templates=[(v, output_spaces[v]) for v in vol_spaces],
     )
 
@@ -309,11 +304,14 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823,
             (('t1w', fix_multi_T1w_source_name), 'inputnode.source_file')]),
         (anat_template_wf, anat_reports_wf, [
             ('outputnode.out_report', 'inputnode.t1w_conform_report')]),
-        (brain_extraction_wf, seg_rpt, [
-            ('outputnode.bias_corrected', 'in_file')]),
-        (t1w_dseg, seg_rpt, [('tissue_class_map', 'in_rois')]),
-        (outputnode, seg_rpt, [('t1w_mask', 'in_mask')]),
-        (seg_rpt, anat_reports_wf, [('out_report', 'inputnode.seg_report')]),
+        (outputnode, anat_reports_wf, [
+            ('t1w_preproc', 'inputnode.t1w_preproc'),
+            ('t1w_dseg', 'inputnode.t1w_dseg'),
+            ('t1w_mask', 'inputnode.t1w_mask'),
+            ('std_t1w', 'inputnode.std_t1w'),
+            ('std_mask', 'inputnode.std_mask')]),
+        (anat_norm_wf, anat_reports_wf, [
+            ('poutputnode.template', 'inputnode.template')]),
         # Connect derivatives
         (anat_template_wf, anat_derivatives_wf, [
             ('outputnode.t1w_valid_list', 'inputnode.source_files')]),
@@ -375,7 +373,8 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823,
         (surface_recon_wf, buffernode, [
             ('outputnode.out_brainmask', 't1w_mask')]),
         (surface_recon_wf, anat_reports_wf, [
-            ('outputnode.out_report', 'inputnode.recon_report')]),
+            ('outputnode.subject_id', 'inputnode.subject_id'),
+            ('outputnode.subjects_dir', 'inputnode.subjects_dir')]),
         (surface_recon_wf, anat_derivatives_wf, [
             ('outputnode.out_aseg', 'inputnode.t1w_fs_aseg'),
             ('outputnode.out_aparc', 'inputnode.t1w_fs_aparc'),

--- a/smriprep/workflows/outputs.py
+++ b/smriprep/workflows/outputs.py
@@ -28,9 +28,8 @@ def init_anat_reports_wf(reportlets_dir, freesurfer,
 
     inputfields = ['source_file', 't1w_conform_report',
                    't1w_preproc', 't1w_dseg', 't1w_mask',
-                   'template', 'std_t1w', 'std_mask']
-    if freesurfer:
-        inputfields += ['subject_id', 'subjects_dir']
+                   'template', 'std_t1w', 'std_mask',
+                   'subject_id', 'subjects_dir']
     inputnode = pe.Node(niu.IdentityInterface(fields=inputfields),
                         name='inputnode')
 

--- a/smriprep/workflows/outputs.py
+++ b/smriprep/workflows/outputs.py
@@ -20,12 +20,22 @@ from ..interfaces import DerivativesDataSink
 def init_anat_reports_wf(reportlets_dir, freesurfer,
                          name='anat_reports_wf'):
     """Set up a battery of datasinks to store reports in the right location."""
+    from niworkflows.interfaces import SimpleBeforeAfter
+    from niworkflows.interfaces.masks import ROIsPlot
+    from ..interfaces.templateflow import TemplateFlowSelect
+
     workflow = Workflow(name=name)
 
-    inputnode = pe.Node(
-        niu.IdentityInterface(
-            fields=['source_file', 't1w_conform_report', 'seg_report', 'recon_report']),
-        name='inputnode')
+    inputfields = ['source_file', 't1w_conform_report',
+                   't1w_preproc', 't1w_dseg', 't1w_mask',
+                   'template', 'std_t1w', 'std_mask']
+    if freesurfer:
+        inputfields += ['subject_id', 'subjects_dir']
+    inputnode = pe.Node(niu.IdentityInterface(fields=inputfields),
+                        name='inputnode')
+
+    seg_rpt = pe.Node(ROIsPlot(colors=['magenta', 'b'], levels=[1.5, 2.5]),
+                      name='seg_rpt')
 
     ds_t1w_conform_report = pe.Node(
         DerivativesDataSink(base_directory=reportlets_dir, desc='conform', keep_dtype=True),
@@ -38,17 +48,57 @@ def init_anat_reports_wf(reportlets_dir, freesurfer,
     workflow.connect([
         (inputnode, ds_t1w_conform_report, [('source_file', 'source_file'),
                                             ('t1w_conform_report', 'in_file')]),
-        (inputnode, ds_t1w_dseg_mask_report, [('source_file', 'source_file'),
-                                              ('seg_report', 'in_file')]),
+        (inputnode, ds_t1w_dseg_mask_report, [('source_file', 'source_file')]),
+        (inputnode, seg_rpt, [('t1w_preproc', 'in_file'),
+                              ('t1w_mask', 'in_mask'),
+                              ('t1w_dseg', 'in_rois')]),
+        (seg_rpt, ds_t1w_dseg_mask_report, [('out_report', 'in_file')]),
+
+    ])
+
+    # Generate reportlets showing spatial normalization
+    tf_select = pe.Node(TemplateFlowSelect(resolution=1),
+                        name='tf_select', run_without_submitting=True)
+    norm_msk = pe.Node(niu.Function(
+        function=_rpt_masks, output_names=['before', 'after'],
+        input_names=['mask_file', 'before', 'after', 'after_mask']),
+        name='norm_msk')
+    norm_rpt = pe.Node(SimpleBeforeAfter(), name='norm_rpt', mem_gb=0.1)
+    norm_rpt.inputs.after_label = 'Participant'  # after
+
+    ds_std_t1w_report = pe.Node(
+        DerivativesDataSink(base_directory=reportlets_dir, suffix='T1w'),
+        name='ds_std_t1w_report', run_without_submitting=True)
+
+    workflow.connect([
+        (inputnode, tf_select, [(('template', _get_name), 'template'),
+                                (('template', _get_spec), 'template_spec')]),
+        (inputnode, norm_rpt, [(('template', _get_name), 'before_label')]),
+        (inputnode, norm_msk, [('std_t1w', 'after'),
+                               ('std_mask', 'after_mask')]),
+        (tf_select, norm_msk, [('t1w_file', 'before'),
+                               ('brain_mask', 'mask_file')]),
+        (norm_msk, norm_rpt, [('before', 'before'),
+                              ('after', 'after')]),
+        (inputnode, ds_std_t1w_report, [
+            (('template', _get_name), 'space'),
+            ('source_file', 'source_file')]),
+        (norm_rpt, ds_std_t1w_report, [('out_report', 'in_file')]),
     ])
 
     if freesurfer:
+        from ..interfaces.reports import FSSurfaceReport
+        recon_report = pe.Node(FSSurfaceReport(), name='recon_report')
+        recon_report.interface._always_run = True
+
         ds_recon_report = pe.Node(
             DerivativesDataSink(base_directory=reportlets_dir, desc='reconall', keep_dtype=True),
             name='ds_recon_report', run_without_submitting=True)
         workflow.connect([
-            (inputnode, ds_recon_report, [('source_file', 'source_file'),
-                                          ('recon_report', 'in_file')])
+            (inputnode, recon_report, [('subjects_dir', 'subjects_dir'),
+                                       ('subject_id', 'subject_id')]),
+            (recon_report, ds_recon_report, [('out_report', 'in_file')]),
+            (inputnode, ds_recon_report, [('source_file', 'source_file')])
         ])
 
     return workflow
@@ -262,5 +312,25 @@ def _rawsources(template):
     return 'tpl-{0}/tpl-{0}_desc-brain_mask.nii.gz'.format(template)
 
 
+def _rpt_masks(mask_file, before, after, after_mask=None):
+    from os.path import abspath
+    import nibabel as nb
+    msk = nb.load(mask_file).get_fdata() > 0
+    bnii = nb.load(before)
+    nb.Nifti1Image(bnii.get_fdata() * msk,
+                   bnii.affine, bnii.header).to_filename('before.nii.gz')
+    if after_mask is not None:
+        msk = nb.load(after_mask).get_fdata() > 0
+
+    anii = nb.load(after)
+    nb.Nifti1Image(anii.get_fdata() * msk,
+                   anii.affine, anii.header).to_filename('after.nii.gz')
+    return abspath('before.nii.gz'), abspath('after.nii.gz')
+
+
 def _get_name(in_tuple):
     return in_tuple[0]
+
+
+def _get_spec(in_tuple):
+    return in_tuple[1]


### PR DESCRIPTION
This PR delays report generation to the ``anat_report_wf`` workflow which is staged at the end. This decoupling will allow creating reportlets from existing derivatives in the context of #107. The most immediate result of decoupling is visible when connecting inputs to ``anat_report_wf`` - most of them are sourced from the ``outputnode`` and the normalization and surfaces reports are not passed in anymore.

For the generation of the surfaces report, the ReconAllRPT interface is dropped, and a new lightweight interface based on ``SimpleInterface`` is included.