### PR TITLE
CI: Run pytests on Python 3.7 for now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,7 @@ jobs:
 
   test_pytest:
     docker:
-      - image: circleci/python:latest
+      - image: circleci/python:3.7.4
     working_directory: /home/circleci/src/smriprep
     steps:
       - checkout


### PR DESCRIPTION
Scipy doesn't have a Python 3.8 wheel yet, and building it is a pain. Dropping pytests back to 3.7 for now.