### PR TITLE
CI: Optimize CircleCI using a local docker registry instead docker save/load

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,25 +79,15 @@ jobs:
           command: |
             docker exec -it registry /bin/registry garbage-collect --delete-untagged \
                 /etc/docker/registry/config.yml
-
-      - persist_to_workspace:
-          root: /tmp
-          paths:
-            - docker
-            - src/smriprep
-
-  update_cache:
-    machine:
-      # Ubuntu 14.04 with Docker 17.10.0-ce
-      image: circleci/classic:201711-01
-    working_directory: /tmp/src/smriprep
-    steps:
-      - attach_workspace:
-          at: /tmp
       - save_cache:
          key: build-v2-{{ .Branch }}-{{ epoch }}
          paths:
             - /tmp/docker
+
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+            - src/smriprep
 
   get_data:
     machine:
@@ -172,6 +162,14 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp
+      - restore_cache:
+          keys:
+            - build-v2-{{ .Branch }}-{{ epoch }}
+            - build-v2-{{ .Branch }}-
+            - build-v2-master-
+            - build-v2-
+          paths:
+            - /tmp/docker
       - run:
           name: Set-up a Docker registry
           command: |
@@ -270,18 +268,24 @@ jobs:
     environment:
       - FS_LICENSE: /tmp/fslicense/license.txt
     steps:
-      - checkout:
-          path: /home/circleci/src/smriprep
+      - attach_workspace:
+          at: /tmp
       - run:
           name: Check whether build should be skipped
           command: |
-            cd /home/circleci/src/smriprep
+            cd /tmp/src/smriprep
             if [[ "$( git log --format=oneline -n 1 $CIRCLE_SHA1 | grep -i -E '\[skip[ _]?ds005\]' )" != "" ]]; then
               echo "Skipping ds000005 build"
               circleci step halt
             fi
-      - attach_workspace:
-          at: /tmp
+      - restore_cache:
+          keys:
+            - build-v2-{{ .Branch }}-{{ epoch }}
+            - build-v2-{{ .Branch }}-
+            - build-v2-master-
+            - build-v2-
+          paths:
+            - /tmp/docker
       - restore_cache:
           keys:
             - ds005-anat-v6-{{ .Branch }}-{{ epoch }}
@@ -368,18 +372,24 @@ jobs:
     environment:
       - FS_LICENSE: /tmp/fslicense/license.txt
     steps:
-      - checkout:
-          path: /home/circleci/src/smriprep
+      - attach_workspace:
+          at: /tmp
       - run:
           name: Check whether build should be skipped
           command: |
-            cd /home/circleci/src/smriprep
+            cd /tmp/src/smriprep
             if [[ "$( git log --format=oneline -n 1 $CIRCLE_SHA1 | grep -i -E '\[skip[ _]?ds054\]' )" != "" ]]; then
               echo "Skipping ds000054 build"
               circleci step halt
             fi
-      - attach_workspace:
-          at: /tmp
+      - restore_cache:
+          keys:
+            - build-v2-{{ .Branch }}-{{ epoch }}
+            - build-v2-{{ .Branch }}-
+            - build-v2-master-
+            - build-v2-
+          paths:
+            - /tmp/docker
       - restore_cache:
           keys:
             - ds054-anat-v6-{{ .Branch }}-{{ epoch }}
@@ -525,8 +535,14 @@ jobs:
       image: circleci/classic:201711-01
     working_directory: /tmp/src/smriprep
     steps:
-      - attach_workspace:
-          at: /tmp
+      - restore_cache:
+          keys:
+            - build-v2-{{ .Branch }}-{{ epoch }}
+            - build-v2-{{ .Branch }}-
+            - build-v2-master-
+            - build-v2-
+          paths:
+            - /tmp/docker
       - run:
           name: Set-up a Docker registry
           command: |
@@ -588,17 +604,6 @@ workflows:
               only: /.*/
 
       - get_data:
-          filters:
-            branches:
-              ignore:
-                - /docs?\/.*/
-                - /tests?\/.*/
-            tags:
-              only: /.*/
-
-      - update_cache:
-          requires:
-            - build
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,43 +1,54 @@
 version: 2
 jobs:
-
   build:
+    machine:
+      image: circleci/classic:201711-01
+    working_directory: /tmp/src/smriprep
     environment:
       TZ: "/usr/share/zoneinfo/America/Los_Angeles"
       SCRATCH: "/scratch"
-    docker:
-      - image: docker:18.01.0-ce-git
-    working_directory: /tmp/src/smriprep
     steps:
-      - run:
-          name: Install parallel gzip and python3
-          command: |
-            apk add --no-cache pigz python3
       - restore_cache:
           keys:
-            - build-v1-{{ .Branch }}-{{ epoch }}
-            - build-v1-{{ .Branch }}-
-            - build-v1-master-
-            - build-v1-
+            - build-v2-{{ .Branch }}-{{ epoch }}
+            - build-v2-{{ .Branch }}-
+            - build-v2-master-
+            - build-v2-
           paths:
-            - /tmp/cache/docker.tar.gz
-            - /tmp/cache/ubuntu.tar.gz
-      - checkout
-      - setup_remote_docker
+            - /tmp/docker
       - run:
-          name: Load Docker image layer cache
-          no_output_timeout: 30m
+          name: Set-up a Docker registry
           command: |
-            docker info
-            set +o pipefail
-            if [ -f /tmp/cache/docker.tar.gz ]; then
-              pigz -d --stdout /tmp/cache/docker.tar.gz | docker load
-              docker images
+            docker run -d -p 5000:5000 --restart=always --name=registry \
+                -v /tmp/docker:/var/lib/registry registry:2
+      - run:
+          name: Pull images
+          command: |
+            set +e
+            docker pull localhost:5000/ubuntu
+            success=$?
+            set -e
+            if [[ "$success" = "0" ]]; then
+                echo "Pulling from local registry"
+                docker tag localhost:5000/ubuntu ubuntu:xenial-20161213
+                docker pull localhost:5000/smriprep
+                docker tag localhost:5000/smriprep poldracklab/smriprep:latest
+                docker tag localhost:5000/smriprep poldracklab/smriprep
+            else
+                echo "Pulling from Docker Hub"
+                docker pull ubuntu:xenial-20161213
+                docker tag ubuntu:xenial-20161213 localhost:5000/ubuntu
+                docker push localhost:5000/ubuntu
+                docker pull poldracklab/smriprep:latest
             fi
+      - checkout
       - run:
           name: Build Docker image
           no_output_timeout: 60m
           command: |
+            export PY3=$(pyenv versions | grep '3\.' |
+                         sed -e 's/.* 3\./3./' -e 's/ .*//')
+            pyenv local $PY3
             # Get version, update files.
             THISVERSION=$( python3 get_version.py )
             if [[ ${THISVERSION:0:1} == "0" ]] ; then
@@ -48,9 +59,8 @@ jobs:
             fi
             # Build docker image
             e=1 && for i in {1..5}; do
-              docker build \
+              docker build --rm \
                 --cache-from=poldracklab/smriprep \
-                --rm=false \
                 -t poldracklab/smriprep:latest \
                 --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
                 --build-arg VCS_REF=`git rev-parse --short HEAD` \
@@ -59,30 +69,35 @@ jobs:
             done && [ "$e" -eq "0" ]
 
       - run:
-          name: Docker save
+          name: Docker push to local registry
           no_output_timeout: 40m
           command: |
-            mkdir -p /tmp/cache
-            docker save ubuntu:xenial-20161213 poldracklab/smriprep:latest \
-            | pigz -8 -p 3 > /tmp/cache/docker.tar.gz
+            docker tag poldracklab/smriprep:latest localhost:5000/smriprep
+            docker push localhost:5000/smriprep
+      - run:
+          name: Docker registry garbage collection
+          command: |
+            docker exec -it registry /bin/registry garbage-collect --delete-untagged \
+                /etc/docker/registry/config.yml
 
       - persist_to_workspace:
           root: /tmp
           paths:
-            - cache/docker.tar.gz
+            - docker
             - src/smriprep
 
   update_cache:
-    docker:
-      - image: docker:18.01.0-ce-git
+    machine:
+      # Ubuntu 14.04 with Docker 17.10.0-ce
+      image: circleci/classic:201711-01
     working_directory: /tmp/src/smriprep
     steps:
       - attach_workspace:
           at: /tmp
       - save_cache:
-         key: build-v1-{{ .Branch }}-{{ epoch }}
+         key: build-v2-{{ .Branch }}-{{ epoch }}
          paths:
-            - /tmp/cache/docker.tar.gz
+            - /tmp/docker
 
   get_data:
     machine:
@@ -155,9 +170,19 @@ jobs:
     machine:
       image: circleci/classic:201808-01
     steps:
-      - checkout
+      - attach_workspace:
+          at: /tmp
       - run:
-          command: docker pull poldracklab/smriprep:latest
+          name: Set-up a Docker registry
+          command: |
+            docker run -d -p 5000:5000 --restart=always --name=registry \
+                -v /tmp/docker:/var/lib/registry registry:2
+      - run:
+          name: Pull images from local registry
+          command: |
+            docker pull localhost:5000/smriprep
+            docker tag localhost:5000/smriprep poldracklab/smriprep:latest
+      - checkout
       - run:
           name: Test smriprep-wrapper (Python 2)
           command: |
@@ -218,39 +243,6 @@ jobs:
       - store_artifacts:
           path: /tmp/data/reports
 
-  deploy_docker:
-    machine:
-      image: circleci/classic:201711-01
-    working_directory: /tmp/src/smriprep
-    steps:
-      - attach_workspace:
-          at: /tmp
-      - run:
-          name: Load Docker image layer cache
-          no_output_timeout: 30m
-          command: |
-            docker info
-            set +o pipefail
-            if [ -f /tmp/cache/docker.tar.gz ]; then
-              sudo apt update && sudo apt -y install pigz
-              pigz -d --stdout /tmp/cache/docker.tar.gz | docker load
-              docker images
-            fi
-      - run:
-          name: Deploy to Docker Hub
-          no_output_timeout: 40m
-          command: |
-            if [[ -n "$DOCKER_PASS" ]]; then
-              docker login -u $DOCKER_USER -p $DOCKER_PASS
-              docker tag poldracklab/smriprep poldracklab/smriprep:unstable
-              docker push poldracklab/smriprep:unstable
-              if [[ -n "$CIRCLE_TAG" ]]; then
-                docker push poldracklab/smriprep:latest
-                docker tag poldracklab/smriprep poldracklab/smriprep:$CIRCLE_TAG
-                docker push poldracklab/smriprep:$CIRCLE_TAG
-              fi
-            fi
-
   test_packaging:
     docker:
       - image: circleci/python:latest
@@ -270,30 +262,6 @@ jobs:
       - run:
           name: Check packages
           command: twine check dist/* wrapper/dist/*
-
-  deploy_pypi:
-    docker:
-      - image: circleci/python:latest
-    working_directory: /home/circleci/src/smriprep
-    steps:
-      - checkout
-      - run:
-          name: Setup Python environment
-          command: |
-            pip install --user --upgrade "setuptools>=30.3.0" "pip>=18.1" twine docutils
-      - run:
-          name: Build sMRIPrep distributions
-          command: python setup.py sdist bdist_wheel
-      - run:
-          name: Build smriprep-docker
-          command: cd wrapper && python setup.py sdist bdist_wheel
-      - run:
-          name: Check packages
-          command: twine check dist/* wrapper/dist/*
-      - run:
-          name: Deploy to PyPi
-          command: |
-            twine upload dist/* wrapper/dist/*
 
   ds005:
     machine:
@@ -334,16 +302,15 @@ jobs:
             sudo setfacl -d -m group:$(id -gn):rwx /tmp/ds005/work && \
                 sudo setfacl -m group:$(id -gn):rwx /tmp/ds005/work
       - run:
-          name: Load Docker image layer cache
-          no_output_timeout: 30m
+          name: Set-up a Docker registry
           command: |
-            docker info
-            set +o pipefail
-            if [ -f /tmp/cache/docker.tar.gz ]; then
-              sudo apt update && sudo apt -y install pigz
-              pigz -d --stdout /tmp/cache/docker.tar.gz | docker load
-              docker images
-            fi
+            docker run -d -p 5000:5000 --restart=always --name=registry \
+                -v /tmp/docker:/var/lib/registry registry:2
+      - run:
+          name: Pull images from local registry
+          command: |
+            docker pull localhost:5000/smriprep
+            docker tag localhost:5000/smriprep poldracklab/smriprep:latest
       - run:
           name: Run anatomical workflow on ds005
           no_output_timeout: 2h
@@ -368,20 +335,29 @@ jobs:
             - /tmp/ds005/work
 
       - run:
-          name: Checking outputs
+          name: Checking outputs of sMRIPrep
           command: |
             mkdir -p /tmp/ds005/test
             find /tmp/ds005/derivatives -name "*" ! -path "*/figures*" ! -path "*/freesurfer*" -print | sed s+/tmp/ds005/derivatives/++ | sort > /tmp/ds005/test/outputs.out
             diff /tmp/src/smriprep/.circleci/ds005_outputs.txt /tmp/ds005/test/outputs.out
             exit $?
-
       - run:
-          name: Clean working directory
+          name: Clean-up work directory
           when: always
           command: |
             sudo chown $(id -un):$(id -gn) -R /tmp/ds005
-            find /tmp/ds005/work -not -name "*.svg" -not -name "*.html" -not -name "*.rst" \
-                -not -name "*.mat" -not -name "*.lta" -not -name "*.json" -not -name "*.txt" -not -name "*.pklz" -type f -delete
+            rm -rf /tmp/ds005/freesurfer
+      - run:
+          name: Clean working directory
+          when: on_success
+          command: |
+            sudo rm -rf /tmp/ds005/work
+      - run:
+          name: Clean working directory
+          when: on_fail
+          command: |
+            find /tmp/ds005/work \( -name "*.nii.gz" -or -name "*.nii" -or "*.gii" -or "*.h5" \) \
+                -exec sh -c 'rm -f {}; touch {}' \;
       - store_artifacts:
           path: /tmp/ds005
 
@@ -419,16 +395,15 @@ jobs:
             sudo setfacl -d -m group:$(id -gn):rwx /tmp/ds054/work && \
                 sudo setfacl -m group:$(id -gn):rwx /tmp/ds054/work
       - run:
-          name: Load Docker image layer cache
-          no_output_timeout: 30m
+          name: Set-up a Docker registry
           command: |
-            docker info
-            set +o pipefail
-            if [ -f /tmp/cache/docker.tar.gz ]; then
-              sudo apt update && sudo apt -y install pigz
-              pigz -d --stdout /tmp/cache/docker.tar.gz | docker load
-              docker images
-            fi
+            docker run -d -p 5000:5000 --restart=always --name=registry \
+                -v /tmp/docker:/var/lib/registry registry:2
+      - run:
+          name: Pull images from local registry
+          command: |
+            docker pull localhost:5000/smriprep
+            docker tag localhost:5000/smriprep poldracklab/smriprep:latest
       - run:
           name: Run sMRIPrep on ds054 (with --fs-no-reconall)
           no_output_timeout: 2h
@@ -458,12 +433,18 @@ jobs:
             diff /tmp/src/smriprep/.circleci/ds054_outputs.txt /tmp/ds054/test/outputs.out
             exit $?
       - run:
-          name: Clean-up work directory
-          when: always
+          name: Clean working directory
+          when: on_success
           command: |
             sudo chown $(id -un):$(id -gn) -R /tmp/ds054
-            find /tmp/ds054/work -not -name "*.svg" -not -name "*.html" -not -name "*.rst" \
-                -not -name "*.mat" -not -name "*.lta" -not -name "*.json" -not -name "*.txt" -not -name "*.pklz" -type f -delete
+            sudo rm -rf /tmp/ds054/work
+      - run:
+          name: Clean working directory
+          when: on_fail
+          command: |
+            sudo chown $(id -un):$(id -gn) -R /tmp/ds054
+            find /tmp/ds054/work \( -name "*.nii.gz" -or -name "*.nii" -or "*.gii" -or "*.h5" \) \
+                -exec sh -c 'rm -f {}; touch {}' \;
       - store_artifacts:
           path: /tmp/ds054
 
@@ -515,6 +496,62 @@ jobs:
       - store_artifacts:
           path: ./docs/_build/html
 
+  deploy_pypi:
+    docker:
+      - image: circleci/python:latest
+    working_directory: /home/circleci/src/smriprep
+    steps:
+      - checkout
+      - run:
+          name: Setup Python environment
+          command: |
+            pip install --user --upgrade "setuptools>=30.3.0" "pip>=18.1" twine docutils
+      - run:
+          name: Build sMRIPrep distributions
+          command: python setup.py sdist bdist_wheel
+      - run:
+          name: Build smriprep-docker
+          command: cd wrapper && python setup.py sdist bdist_wheel
+      - run:
+          name: Check packages
+          command: twine check dist/* wrapper/dist/*
+      - run:
+          name: Deploy to PyPi
+          command: |
+            twine upload dist/* wrapper/dist/*
+
+  deploy_docker:
+    machine:
+      image: circleci/classic:201711-01
+    working_directory: /tmp/src/smriprep
+    steps:
+      - attach_workspace:
+          at: /tmp
+      - run:
+          name: Set-up a Docker registry
+          command: |
+            docker run -d -p 5000:5000 --restart=always --name=registry \
+                -v /tmp/docker:/var/lib/registry registry:2
+      - run:
+          name: Pull images from local registry
+          command: |
+            docker pull localhost:5000/smriprep
+            docker tag localhost:5000/smriprep poldracklab/smriprep:latest
+      - run:
+          name: Deploy to Docker Hub
+          no_output_timeout: 40m
+          command: |
+            if [[ -n "$DOCKER_PASS" ]]; then
+              docker login -u $DOCKER_USER -p $DOCKER_PASS
+              docker tag poldracklab/smriprep poldracklab/smriprep:unstable
+              docker push poldracklab/smriprep:unstable
+              if [[ -n "$CIRCLE_TAG" ]]; then
+                docker push poldracklab/smriprep:latest
+                docker tag poldracklab/smriprep poldracklab/smriprep:$CIRCLE_TAG
+                docker push poldracklab/smriprep:$CIRCLE_TAG
+              fi
+            fi
+
   deploy_docs:
     docker:
       - image: node:8.10.0
@@ -559,28 +596,6 @@ workflows:
             tags:
               only: /.*/
 
-      - build_docs:
-          filters:
-            branches:
-              ignore:
-                - /tests?\/.*/
-                - /ds005\/.*/
-                - /ds054\/.*/
-            tags:
-              only: /.*/
-
-      - deploy_docs:
-          requires:
-            - build_docs
-            - deploy_docker
-            - deploy_pypi
-          filters:
-            branches:
-              only:
-                - /master/
-            tags:
-              only: /.*/
-
       - update_cache:
           requires:
             - build
@@ -613,6 +628,8 @@ workflows:
               only: /.*/
 
       - test_wrapper:
+          requires:
+            - build
           filters:
             branches:
               ignore:
@@ -622,29 +639,13 @@ workflows:
             tags:
               only: /.*/
 
-      - deploy_docker:
-          requires:
-            - build
-            - test_pytest
-            - ds005
-            - ds054
-            # - build_docs
+      - build_docs:
           filters:
             branches:
-              only: master
-            tags:
-              only: /.*/
-
-      - deploy_pypi:
-          requires:
-            - test_packaging
-            - test_pytest
-            - test_wrapper
-            - ds005
-            - ds054
-          filters:
-            branches:
-              ignore: /.*/
+              ignore:
+                - /tests?\/.*/
+                - /ds005\/.*/
+                - /ds054\/.*/
             tags:
               only: /.*/
 
@@ -671,5 +672,42 @@ workflows:
                 - /docs?\/.*/
                 - /tests?\/.*/
                 - /ds005\/.*/
+            tags:
+              only: /.*/
+
+      - deploy_docs:
+          requires:
+            - build_docs
+            - deploy_docker
+            - deploy_pypi
+          filters:
+            branches:
+              only:
+                - /master/
+            tags:
+              only: /.*/
+
+      - deploy_pypi:
+          requires:
+            - test_packaging
+            - test_pytest
+            - test_wrapper
+            - ds005
+            - ds054
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /.*/
+
+      - deploy_docker:
+          requires:
+            - build
+            - test_pytest
+            - ds005
+            - ds054
+          filters:
+            branches:
+              only: master
             tags:
               only: /.*/


### PR DESCRIPTION
Seems like replacing the docker save/load approach with a local registry run on the same machine allows us to make the main build job ~8min lighter and smoke tests builds ~6min lighter.

This is probably not a big deal time-wise, but I think this approach is more reliable than the docker save/load, and will escalate better if CircleCI opens up to having service jobs or some such.

This PR also revises the artifacts being collected - which were too many for successful runs (including the work directory and freesurfer folder).

The idea is to test how this works for sMRIPrep and then propagate to fMRIPrep and other projects if things look good.