### PR TITLE
FIX: Normalization workflow API - provide bare template names

### DIFF
--- a/smriprep/interfaces/templateflow.py
+++ b/smriprep/interfaces/templateflow.py
@@ -66,3 +66,38 @@ class TemplateFlowSelect(SimpleInterface):
             **specs
         )
         return runtime
+
+
+class _TemplateDescInputSpec(BaseInterfaceInputSpec):
+    template = traits.Tuple(traits.Str, traits.Dict, mandatory=True,
+                            desc='(id, description) pair')
+
+
+class _TemplateDescOutputSpec(TraitedSpec):
+    name = traits.Str(desc='template identifier')
+    spec = traits.Dict(desc='template arguments')
+
+
+class TemplateDesc(SimpleInterface):
+    """
+    Select template description and name pairs.
+
+    This interface is necessary to ensure the good functioning
+    with iterables and JoinNodes.
+
+    >>> select = TemplateDesc(template=('MNI152NLin2009cAsym', {}))
+    >>> result = select.run()
+    >>> result.outputs.name
+    'MNI152NLin2009cAsym'
+
+    >>> result.outputs.spec
+    {}
+
+    """
+
+    input_spec = _TemplateDescInputSpec
+    output_spec = _TemplateDescOutputSpec
+
+    def _run_interface(self, runtime):
+        self._results['name'], self._results['spec'] = self.inputs.template
+        return runtime

--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -306,7 +306,8 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823,
             ('std_t1w', 'inputnode.std_t1w'),
             ('std_mask', 'inputnode.std_mask')]),
         (anat_norm_wf, anat_reports_wf, [
-            ('poutputnode.template', 'inputnode.template')]),
+            ('poutputnode.template', 'inputnode.template'),
+            ('poutputnode.template_spec', 'inputnode.template_spec')]),
         # Connect derivatives
         (anat_template_wf, anat_derivatives_wf, [
             ('outputnode.t1w_valid_list', 'inputnode.source_files')]),

--- a/smriprep/workflows/norm.py
+++ b/smriprep/workflows/norm.py
@@ -180,7 +180,7 @@ The following template{tpls} selected for spatial normalization:
         (std_mask, poutputnode, [('output_image', 'std_mask')]),
         (std_dseg, poutputnode, [('output_image', 'std_dseg')]),
         (std_tpms, poutputnode, [('output_image', 'std_tpms')]),
-        (inputnode, poutputnode, [('template', 'template')]),
+        (inputnode, poutputnode, [(('template', _get_name), 'template')]),
     ])
 
     # Provide synchronized output

--- a/smriprep/workflows/outputs.py
+++ b/smriprep/workflows/outputs.py
@@ -22,7 +22,7 @@ def init_anat_reports_wf(reportlets_dir, freesurfer,
 
     inputfields = ['source_file', 't1w_conform_report',
                    't1w_preproc', 't1w_dseg', 't1w_mask',
-                   'template', 'std_t1w', 'std_mask',
+                   'template', 'template_spec', 'std_t1w', 'std_mask',
                    'subject_id', 'subjects_dir']
     inputnode = pe.Node(niu.IdentityInterface(fields=inputfields),
                         name='inputnode')
@@ -64,9 +64,9 @@ def init_anat_reports_wf(reportlets_dir, freesurfer,
         name='ds_std_t1w_report', run_without_submitting=True)
 
     workflow.connect([
-        (inputnode, tf_select, [(('template', _get_name), 'template'),
-                                (('template', _get_spec), 'template_spec')]),
-        (inputnode, norm_rpt, [(('template', _get_name), 'before_label')]),
+        (inputnode, tf_select, [('template', 'template'),
+                                ('template_spec', 'template_spec')]),
+        (inputnode, norm_rpt, [('template', 'before_label')]),
         (inputnode, norm_msk, [('std_t1w', 'after'),
                                ('std_mask', 'after_mask')]),
         (tf_select, norm_msk, [('t1w_file', 'before'),
@@ -74,7 +74,7 @@ def init_anat_reports_wf(reportlets_dir, freesurfer,
         (norm_msk, norm_rpt, [('before', 'before'),
                               ('after', 'after')]),
         (inputnode, ds_std_t1w_report, [
-            (('template', _get_name), 'space'),
+            ('template', 'space'),
             ('source_file', 'source_file')]),
         (norm_rpt, ds_std_t1w_report, [('out_report', 'in_file')]),
     ])
@@ -193,23 +193,23 @@ def init_anat_derivatives_wf(bids_root, freesurfer, num_t1w, output_dir,
         # Template
         (inputnode, ds_t1w_tpl_warp, [
             ('anat2std_xfm', 'in_file'),
-            (('template', _get_name), 'to')]),
+            ('template', 'to')]),
         (inputnode, ds_t1w_tpl_inv_warp, [
             ('std2anat_xfm', 'in_file'),
-            (('template', _get_name), 'from')]),
+            ('template', 'from')]),
         (inputnode, ds_t1w_tpl, [
             ('std_t1w', 'in_file'),
-            (('template', _get_name), 'space')]),
+            ('template', 'space')]),
         (inputnode, ds_std_mask, [
             ('std_mask', 'in_file'),
-            (('template', _get_name), 'space'),
+            ('template', 'space'),
             (('template', _rawsources), 'RawSources')]),
-        (inputnode, ds_std_dseg, [(('template', _get_name), 'space')]),
+        (inputnode, ds_std_dseg, [('template', 'space')]),
         (inputnode, lut_std_dseg, [('std_dseg', 'in_file')]),
         (lut_std_dseg, ds_std_dseg, [('out', 'in_file')]),
         (inputnode, ds_std_tpms, [
             ('std_tpms', 'in_file'),
-            (('template', _get_name), 'space')]),
+            ('template', 'space')]),
         (t1w_name, ds_t1w_tpl_warp, [('out', 'source_file')]),
         (t1w_name, ds_t1w_tpl_inv_warp, [('out', 'source_file')]),
         (t1w_name, ds_t1w_tpl, [('out', 'source_file')]),
@@ -327,11 +327,3 @@ def _rpt_masks(mask_file, before, after, after_mask=None):
     nb.Nifti1Image(anii.get_fdata() * msk,
                    anii.affine, anii.header).to_filename('after.nii.gz')
     return abspath('before.nii.gz'), abspath('after.nii.gz')
-
-
-def _get_name(in_tuple):
-    return in_tuple[0]
-
-
-def _get_spec(in_tuple):
-    return in_tuple[1]


### PR DESCRIPTION
[A recent change](https://github.com/poldracklab/smriprep/commit/4d06de1da75b9bbabf913bb8088a74a076f14b5e#diff-22ed5ba333295a58e8031657cba4de41) is provoking [this error](https://github.com/poldracklab/fmriprep/pull/1827#issuecomment-542502578). This PR fixes the problem.