### PR TITLE
fix: empty specs for legacy/nonstd spaces

### DIFF
--- a/smriprep/cli/tests/test_utils.py
+++ b/smriprep/cli/tests/test_utils.py
@@ -47,13 +47,13 @@ def test_template_parser(monkeypatch):
             u._template(['MNI152NLin6Asym:res-2', 'func'])
 
         assert u._template(['MNI152NLin6Asym:res-2', 'fsnative']) == \
-            OrderedDict([('MNI152NLin6Asym', {'res': '2'}), ('fsnative', None)])
+            OrderedDict([('MNI152NLin6Asym', {'res': '2'}), ('fsnative', {})])
 
         u.ParseTemplates.set_nonstandard_spaces('func')
         assert u._template(['MNI152NLin2009cAsym:res-2', 'func']) == \
-            OrderedDict([('MNI152NLin2009cAsym', {'res': '2'}), ('func', None)])
+            OrderedDict([('MNI152NLin2009cAsym', {'res': '2'}), ('func', {})])
 
         u.ParseTemplates.set_nonstandard_spaces(['func', 'fsnative'])
         assert u._template(['MNI152NLin2009cAsym:res-2', 'func', 'fsnative']) == \
             OrderedDict([('MNI152NLin2009cAsym', {'res': '2'}),
-                         ('func', None), ('fsnative', None)])
+                         ('func', {}), ('fsnative', {})])

--- a/smriprep/cli/utils.py
+++ b/smriprep/cli/utils.py
@@ -44,10 +44,7 @@ def output_space(value):
         mitems = modifier.split('-', 1)
         spec[mitems[0]] = len(mitems) == 1 or mitems[1]
 
-    if template in ParseTemplates.EXCEPTIONS:
-        return template, {}
-
-    if template in LEGACY_SPACES:
+    if template in ParseTemplates.EXCEPTIONS or template in LEGACY_SPACES:
         return template, {}
 
     if template not in _TF_TEMPLATES:

--- a/smriprep/cli/utils.py
+++ b/smriprep/cli/utils.py
@@ -45,10 +45,10 @@ def output_space(value):
         spec[mitems[0]] = len(mitems) == 1 or mitems[1]
 
     if template in ParseTemplates.EXCEPTIONS:
-        return template, None
+        return template, {}
 
     if template in LEGACY_SPACES:
-        return template, None
+        return template, {}
 
     if template not in _TF_TEMPLATES:
         raise ValueError("""\


### PR DESCRIPTION
Closes #145 