### PR TITLE
FIX: Use T2/FLAIR refinement at cortribbon stage

### DIFF
--- a/smriprep/workflows/surfaces.py
+++ b/smriprep/workflows/surfaces.py
@@ -340,8 +340,13 @@ def init_autorecon_resume_wf(omp_nthreads, name='autorecon_resume_wf'):
     autorecon_surfs.interface._always_run = True
 
     # -cortribbon is a prerequisite for -parcstats, -parcstats2, -parcstats3
-    cortribbon = pe.Node(ReconAll(directive=Undefined,
-                                  steps=['cortribbon']), name='cortribbon')
+    # Claiming two threads because pial refinement can be split by hemisphere
+    # if -T2pial or -FLAIRpial is enabled.
+    # Parallelizing by hemisphere saves ~30 minutes over simply enabling
+    # OpenMP on an 8 core machine.
+    cortribbon = pe.Node(ReconAll(directive=Undefined, steps=['cortribbon'],
+                                  parallel=True),
+                         n_procs=2, name='cortribbon')
     cortribbon.interface._always_run = True
 
     # -parcstats* can be run per-hemisphere

--- a/smriprep/workflows/surfaces.py
+++ b/smriprep/workflows/surfaces.py
@@ -372,8 +372,8 @@ def init_autorecon_resume_wf(omp_nthreads, name='autorecon_resume_wf'):
         return vals.pop()
 
     workflow.connect([
-        (inputnode, autorecon_surfs, [('use_T2', 'use_T2'),
-                                      ('use_FLAIR', 'use_FLAIR')]),
+        (inputnode, cortribbon, [('use_T2', 'use_T2'),
+                                 ('use_FLAIR', 'use_FLAIR')]),
         (inputnode, autorecon2_vol, [('subjects_dir', 'subjects_dir'),
                                      ('subject_id', 'subject_id')]),
         (autorecon2_vol, autorecon_surfs, [('subjects_dir', 'subjects_dir'),


### PR DESCRIPTION
Reported in [Neurostars #5564](https://neurostars.org/t/autorecon-surfs0-mrisread-rh-white-could-not-open-file/5564), T2 processing in FreeSurfer runs into a data dependency failure because we're running `-T2pial` in `-autorecon-hemi` stage, while it needs to run immediately before `-cortribbon`.

It's pretty coarse. There's a part that has to be run serially, and then a part that can be parallelized across hemispheres. By using `-parallel`, we can get the parallelism, at the cost of 2x cores for the whole process. If nothing in [`-T2pial`, `-surfvolume` or `-cortribbon`](https://github.com/freesurfer/freesurfer/blob/2beb96c6099d96508246c14a24136863124566a3/scripts/recon-all#L4147-L4391) can take advantage of OpenMP parallelism, then this will be a 2-core job, which seems acceptable. If something can, it will probably be worth comparing to see which provides the better speedup.