### PR TITLE
ENH: Add smriprep.__main__ to allow python -m smriprep

### DIFF
--- a/smriprep/__main__.py
+++ b/smriprep/__main__.py
@@ -1,0 +1,8 @@
+from .cli.run import main
+
+if __name__ == '__main__':
+    import sys
+    # `python -m smriprep` typically displays the command as __main__.py
+    if '__main__.py' in sys.argv[0]:
+        sys.argv[0] = '%s -m smriprep' % sys.executable
+    main()


### PR DESCRIPTION
This will make it easier to do things like:

```
docker run --entrypoint=coverage poldracklab/smriprep:latest run -m smriprep ...
```

Because coverage takes scripts by default, the alternative is to hard-code the full path.