### PR TITLE
FIX: Calculate FoV with shape and zooms

### DIFF
--- a/smriprep/workflows/surfaces.py
+++ b/smriprep/workflows/surfaces.py
@@ -542,9 +542,12 @@ def init_segs_to_native_wf(name='segs_to_native', segmentation='aseg'):
 
 
 def _check_cw256(in_files):
+    import numpy as np
     from nibabel.funcs import concat_images
     if isinstance(in_files, str):
         in_files = [in_files]
-    if any((s > 256 for s in concat_images(in_files).shape[:3])):
+    summary_img = concat_images(in_files)
+    fov = np.array(summary_img.shape[:3]) * summary_img.header.get_zooms()[:3]
+    if np.any(fov > 256):
         return ['-noskullstrip', '-cw256']
     return '-noskullstrip'


### PR DESCRIPTION
Intended for a bug-fix release 0.4.2.

Closes #160.

Ref: #29, #36.