### PR TITLE
ENH: Enable anatomical fast track reusing existing derivatives

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,17 +118,6 @@ jobs:
          paths:
             - /tmp/docker
 
-      - run:
-          name: Check --fast-track (requires repo checkout)
-          command: |
-            touch /tmp/.fastrack
-            if [[ "$CIRCLE_BRANCH" != "master" ]]; then
-                echo "--fast-track" > /tmp/.fastrack
-            fi
-            if [[ "$( git log --format=oneline -n 1 $CIRCLE_SHA1 | grep -i -E '\[force[ _-]build\]' )" != "" ]]; then
-                echo "" > /tmp/.fastrack
-            fi
-
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -434,7 +423,7 @@ jobs:
           name: Run anatomical workflow on ds005
           no_output_timeout: 2h
           command: |
-            bash /tmp/src/smriprep/.circleci/ds005_run.sh --write-graph $( cat /tmp/.fastrack )
+            bash /tmp/src/smriprep/.circleci/ds005_run.sh --write-graph
       - run:
           name: Combine coverage
           no_output_timeout: 2h
@@ -506,7 +495,7 @@ jobs:
           name: Check fast track using existing derivatives
           no_output_timeout: 5m
           command: |
-            bash /tmp/src/smriprep/.circleci/ds005_run.sh
+            bash /tmp/src/smriprep/.circleci/ds005_run.sh --fast-track
       - run:
           name: Clean working directory
           when: on_fail
@@ -592,7 +581,7 @@ jobs:
           name: Run sMRIPrep on ds054 (with --fs-no-reconall)
           no_output_timeout: 2h
           command: |
-            bash /tmp/src/smriprep/.circleci/ds054_run.sh --write-graph $( cat /tmp/.fastrack )
+            bash /tmp/src/smriprep/.circleci/ds054_run.sh --write-graph
       - run:
           name: Combine coverage
           no_output_timeout: 2h
@@ -663,7 +652,7 @@ jobs:
           name: Check fast track using existing derivatives (with --fs-no-reconall)
           no_output_timeout: 5m
           command: |
-            bash /tmp/src/smriprep/.circleci/ds054_run.sh
+            bash /tmp/src/smriprep/.circleci/ds054_run.sh --fast-track
       - store_artifacts:
           path: /tmp/ds054/work
           destination: fasttrack-work

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,10 +118,22 @@ jobs:
          paths:
             - /tmp/docker
 
+      - run:
+          name: Check --force-build (requires repo checkout)
+          command: |
+            touch /tmp/.force
+            if [[ "$CIRCLE_BRANCH" == "master" ]]; then
+                echo "--force-build" > /tmp/.force
+            fi
+            if [[ "$( git log --format=oneline -n 1 $CIRCLE_SHA1 | grep -i -E '\[force[ _-]build\]' )" != "" ]]; then
+                echo "--force-build" > /tmp/.force
+            fi
+
       - persist_to_workspace:
           root: /tmp
           paths:
             - src/smriprep
+            - .force
 
   get_data:
     docker:
@@ -437,7 +449,7 @@ jobs:
                 -w /tmp/ds005/work \
                 --skull-strip-template MNI152NLin2009cAsym:res-2 \
                 --sloppy --write-graph --mem-gb 4 \
-                --ncpus 2 --omp-nthreads 2 -vv \
+                --ncpus 2 --omp-nthreads 2 -vv $( cat /tmp/.force ) \
                 --fs-license-file /tmp/fslicense/license.txt \
                 --fs-subjects-dir /tmp/ds005/freesurfer
       - run:
@@ -614,7 +626,7 @@ jobs:
                 -w /tmp/ds054/work --fs-no-reconall --sloppy --write-graph \
                 --skull-strip-template OASIS30ANTs:res-1 \
                 --output-spaces MNI152Lin MNI152NLin2009cAsym \
-                --mem-gb 4 --ncpus 2 --omp-nthreads 2 -vv \
+                --mem-gb 4 --ncpus 2 --omp-nthreads 2 -vv $( cat /tmp/.force ) \
                 --fs-license-file /tmp/fslicense/license.txt
       - run:
           name: Combine coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,14 +119,14 @@ jobs:
             - /tmp/docker
 
       - run:
-          name: Check --force-build (requires repo checkout)
+          name: Check --fast-track (requires repo checkout)
           command: |
-            touch /tmp/.force
-            if [[ "$CIRCLE_BRANCH" == "master" ]]; then
-                echo "--force-build" > /tmp/.force
+            touch /tmp/.fastrack
+            if [[ "$CIRCLE_BRANCH" != "master" ]]; then
+                echo "--fast-track" > /tmp/.fastrack
             fi
             if [[ "$( git log --format=oneline -n 1 $CIRCLE_SHA1 | grep -i -E '\[force[ _-]build\]' )" != "" ]]; then
-                echo "--force-build" > /tmp/.force
+                echo "" > /tmp/.fastrack
             fi
 
       - persist_to_workspace:
@@ -434,7 +434,7 @@ jobs:
           name: Run anatomical workflow on ds005
           no_output_timeout: 2h
           command: |
-            bash /tmp/src/smriprep/.circleci/ds005_run.sh --write-graph $( cat /tmp/.force )
+            bash /tmp/src/smriprep/.circleci/ds005_run.sh --write-graph $( cat /tmp/.fastrack )
       - run:
           name: Combine coverage
           no_output_timeout: 2h
@@ -592,7 +592,7 @@ jobs:
           name: Run sMRIPrep on ds054 (with --fs-no-reconall)
           no_output_timeout: 2h
           command: |
-            bash /tmp/src/smriprep/.circleci/ds054_run.sh --write-graph $( cat /tmp/.force )
+            bash /tmp/src/smriprep/.circleci/ds054_run.sh --write-graph $( cat /tmp/.fastrack )
       - run:
           name: Combine coverage
           no_output_timeout: 2h

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,9 +142,9 @@ jobs:
     steps:
       - restore_cache:
           keys:
-            - testdata-v1-{{ .Branch }}-{{ epoch }}
-            - testdata-v1-{{ .Branch }}
-            - testdata-v1-
+            - testdata-v2-{{ .Branch }}-{{ epoch }}
+            - testdata-v2-{{ .Branch }}
+            - testdata-v2-
       - run:
           name: Get test data from ds000005
           command: |
@@ -188,11 +188,12 @@ jobs:
           paths:
             - fslicense
       - save_cache:
-          key: testdata-v1-{{ .Branch }}-{{ epoch }}
+          key: testdata-v2-{{ .Branch }}-{{ epoch }}
           paths:
             - /tmp/data
             - /tmp/ds005/freesurfer
-      - checkout
+      - checkout:
+          path: /tmp/src/smriprep
       - restore_cache:
           keys:
             - templateflow-v1-{{ .Branch }}-{{ epoch }}
@@ -207,7 +208,7 @@ jobs:
           name: Pull TemplateFlow down, pre-cache some templates
           command: |
             export TEMPLATEFLOW_HOME=/tmp/templateflow
-            pip install -U --user --no-cache-dir "$( grep templateflow setup.cfg | xargs )"
+            pip install -U --user --no-cache-dir "$( grep templateflow /tmp/src/smriprep/setup.cfg | xargs )"
             python -c "from templateflow import api as tfapi; \
                        tfapi.get(['MNI152Lin', 'MNI152NLin2009cAsym', 'OASIS30ANTs'], suffix='T1w'); \
                        tfapi.get(['MNI152Lin', 'MNI152NLin2009cAsym', 'OASIS30ANTs'], desc='brain', suffix='mask'); \
@@ -382,9 +383,9 @@ jobs:
             - ds005-anat-v6-
       - restore_cache:
           keys:
-            - testdata-v1-{{ .Branch }}-{{ epoch }}
-            - testdata-v1-{{ .Branch }}
-            - testdata-v1-
+            - testdata-v2-{{ .Branch }}-{{ epoch }}
+            - testdata-v2-{{ .Branch }}
+            - testdata-v2-
 
       - run:
           name: Setting up test
@@ -421,9 +422,9 @@ jobs:
             - ds005-anat-v6-
       - restore_cache:
           keys:
-            - testdata-v1-{{ .Branch }}-{{ epoch }}
-            - testdata-v1-{{ .Branch }}
-            - testdata-v1-
+            - testdata-v2-{{ .Branch }}-{{ epoch }}
+            - testdata-v2-{{ .Branch }}
+            - testdata-v2-
       - restore_cache:
           keys:
             - templateflow-v1-{{ .Branch }}-{{ epoch }}
@@ -433,47 +434,27 @@ jobs:
           name: Run anatomical workflow on ds005
           no_output_timeout: 2h
           command: |
-            docker run --rm=false -it \
-                -v /tmp/data:/tmp/data:ro \
-                -v /tmp/fslicense:/tmp/fslicense:ro \
-                -v /tmp/ds005:/tmp/ds005 \
-                -v /tmp/templateflow:/home/smriprep/.cache/templateflow \
-                -v /tmp/src/smriprep/.circleci/nipype.cfg:/home/smriprep/.nipype/nipype.cfg \
-                -e FMRIPREP_DEV=1 -u $(id -u) \
-                -e COVERAGE_FILE=/tmp/ds005/work/.coverage \
-                -e COVERAGE_RCFILE=/src/smriprep/docker/multiproc.coveragerc \
-                --entrypoint=coverage \
-                poldracklab/smriprep:latest \
-                run -m smriprep \
-                /tmp/data/ds005 /tmp/ds005/derivatives participant \
-                -w /tmp/ds005/work \
-                --skull-strip-template MNI152NLin2009cAsym:res-2 \
-                --sloppy --write-graph --mem-gb 4 \
-                --ncpus 2 --omp-nthreads 2 -vv $( cat /tmp/.force ) \
-                --fs-license-file /tmp/fslicense/license.txt \
-                --fs-subjects-dir /tmp/ds005/freesurfer
+            bash /tmp/src/smriprep/.circleci/ds005_run.sh --write-graph $( cat /tmp/.force )
       - run:
           name: Combine coverage
           no_output_timeout: 2h
           command: |
             # Combine coverage and convert to XML inside container because
             # the file format is sensitive to changes in environment
-            docker run --rm=false -it \
+            docker run -it -e FMRIPREP_DEV=1 -u $(id -u) \
                 -v /tmp/ds005:/tmp/ds005 \
                 -v /tmp/src/smriprep:/src/smriprep \
                 -w /src/smriprep \
-                -e FMRIPREP_DEV=1 -u $(id -u) \
                 -e COVERAGE_FILE=/tmp/ds005/work/.coverage \
                 -e COVERAGE_RCFILE=/src/smriprep/docker/multiproc.coveragerc \
                 --entrypoint=coverage \
                 poldracklab/smriprep:latest \
                 combine /tmp/ds005/work/.coverage.*
             # Convert to XML to freeze
-            docker run --rm=false -it \
+            docker run -it -e FMRIPREP_DEV=1 -u $(id -u) \
                 -v /tmp/ds005:/tmp/ds005 \
                 -v /tmp/src/smriprep:/src/smriprep \
                 -w /src/smriprep \
-                -e FMRIPREP_DEV=1 -u $(id -u) \
                 -e COVERAGE_FILE=/tmp/ds005/work/.coverage \
                 -e COVERAGE_RCFILE=/src/smriprep/docker/multiproc.coveragerc \
                 --entrypoint=coverage \
@@ -488,11 +469,12 @@ jobs:
               python --version
               codecov --file coverage.xml --flags ds005 -e CIRCLE_JOB
       - run:
-          name: Clean-up temporary directory of reportlets
+          name: Clean-up temporary directory of reportlets and fsdir_run_XXX nodes
           when: always
           command: |
             sudo chown $(id -un):$(id -gn) -R /tmp/ds005
             rm -rf /tmp/ds005/work/reportlets
+            rm -rf /tmp/ds005/work/smriprep_wf/fsdir_run_*/
       - save_cache:
          key: ds005-anat-v6-{{ .Branch }}-{{ epoch }}
          paths:
@@ -502,14 +484,11 @@ jobs:
           name: Checking outputs of sMRIPrep
           command: |
             mkdir -p /tmp/ds005/test
-            find /tmp/ds005/derivatives -name "*" ! -path "*/figures*" ! -path "*/freesurfer*" -print | sed s+/tmp/ds005/derivatives/++ | sort > /tmp/ds005/test/outputs.out
+            find /tmp/ds005/derivatives -name "*" ! -path "*/figures*" -print | sed s+/tmp/ds005/derivatives/++ | sort > /tmp/ds005/test/outputs.out
             diff /tmp/src/smriprep/.circleci/ds005_outputs.txt /tmp/ds005/test/outputs.out
             exit $?
-      - run:
-          name: Clean-up work directory
-          when: always
-          command: |
-            rm -rf /tmp/ds005/freesurfer
+      - store_artifacts:
+          path: /tmp/ds005/derivatives
       - run:
           name: Clean working directory
           when: on_success
@@ -519,25 +498,28 @@ jobs:
           name: Clean working directory
           when: on_fail
           command: |
-            find /tmp/ds005/work \( -name "*.nii.gz" -or -name "*.nii" -or "*.gii" -or "*.h5" \) \
+            find /tmp/ds005/work \( -name "*.nii.gz" -or -name "*.nii" -or -name "*.gii" -or -name "*.h5" \) \
                 -exec sh -c 'rm -f {}; touch {}' \;
       - store_artifacts:
-          path: /tmp/ds005
-
+          path: /tmp/ds005/work
       - run:
           name: Check fast track using existing derivatives
           no_output_timeout: 5m
           command: |
-            docker run --rm=false -it -v /tmp:/tmp \
-                -e FMRIPREP_DEV=1 -u $(id -u) \
-                poldracklab/smriprep:latest \
-                /tmp/data/ds005 /tmp/ds005/derivatives participant \
-                 -w /tmp/data/ds005/work \
-                --skull-strip-template MNI152NLin2009cAsym:res-2 \
-                --sloppy --write-graph --mem-gb 4 \
-                --ncpus 2 --omp-nthreads 2 -vv \
-                --fs-license-file /tmp/fslicense/license.txt
-
+            bash /tmp/src/smriprep/.circleci/ds005_run.sh
+      - run:
+          name: Clean working directory
+          when: on_fail
+          command: |
+            rm -rf /tmp/ds005/work/smriprep_wf/fsdir_run_*/
+            find /tmp/ds005/work \( -name "*.nii.gz" -or -name "*.nii" -or -name "*.gii" -or -name "*.h5" \) \
+                -exec sh -c 'rm -f {}; touch {}' \;
+      - store_artifacts:
+          path: /tmp/ds005/work
+          destination: fasttrack
+      - store_artifacts:
+          path: /tmp/ds005/derivatives
+          destination: fasttrack
   ds054:
     machine:
       image: circleci/classic:201711-01
@@ -598,9 +580,9 @@ jobs:
             - ds054-anat-v6-
       - restore_cache:
           keys:
-            - testdata-v1-{{ .Branch }}-{{ epoch }}
-            - testdata-v1-{{ .Branch }}
-            - testdata-v1-
+            - testdata-v2-{{ .Branch }}-{{ epoch }}
+            - testdata-v2-{{ .Branch }}
+            - testdata-v2-
       - restore_cache:
           keys:
             - templateflow-v1-{{ .Branch }}-{{ epoch }}
@@ -610,24 +592,7 @@ jobs:
           name: Run sMRIPrep on ds054 (with --fs-no-reconall)
           no_output_timeout: 2h
           command: |
-            docker run --rm=false -it \
-                -v /tmp/data:/tmp/data:ro \
-                -v /tmp/fslicense:/tmp/fslicense:ro \
-                -v /tmp/ds054:/tmp/ds054 \
-                -v /tmp/templateflow:/home/smriprep/.cache/templateflow \
-                -v /tmp/src/smriprep/.circleci/nipype.cfg:/home/smriprep/.nipype/nipype.cfg \
-                -e FMRIPREP_DEV=1 -u $(id -u) \
-                -e COVERAGE_FILE=/tmp/ds054/work/.coverage \
-                -e COVERAGE_RCFILE=/src/smriprep/docker/multiproc.coveragerc \
-                --entrypoint=coverage \
-                poldracklab/smriprep:latest \
-                run -m smriprep \
-                /tmp/data/ds054 /tmp/ds054/derivatives participant \
-                -w /tmp/ds054/work --fs-no-reconall --sloppy --write-graph \
-                --skull-strip-template OASIS30ANTs:res-1 \
-                --output-spaces MNI152Lin MNI152NLin2009cAsym \
-                --mem-gb 4 --ncpus 2 --omp-nthreads 2 -vv $( cat /tmp/.force ) \
-                --fs-license-file /tmp/fslicense/license.txt
+            bash /tmp/src/smriprep/.circleci/ds054_run.sh --write-graph $( cat /tmp/.force )
       - run:
           name: Combine coverage
           no_output_timeout: 2h
@@ -684,14 +649,12 @@ jobs:
           name: Clean working directory
           when: on_success
           command: |
-            sudo chown $(id -un):$(id -gn) -R /tmp/ds054
             sudo rm -rf /tmp/ds054/work
       - run:
           name: Clean working directory
           when: on_fail
           command: |
-            sudo chown $(id -un):$(id -gn) -R /tmp/ds054
-            find /tmp/ds054/work \( -name "*.nii.gz" -or -name "*.nii" -or "*.gii" -or "*.h5" \) \
+            find /tmp/ds054/work \( -name "*.nii.gz" -or -name "*.nii" -or -name "*.gii" -or -name "*.h5" \) \
                 -exec sh -c 'rm -f {}; touch {}' \;
       - store_artifacts:
           path: /tmp/ds054
@@ -700,16 +663,13 @@ jobs:
           name: Check fast track using existing derivatives (with --fs-no-reconall)
           no_output_timeout: 5m
           command: |
-            docker run --rm=false -it -v /tmp:/tmp \
-                -e FMRIPREP_DEV=1 -u $(id -u) \
-                poldracklab/smriprep:latest \
-                /tmp/data/ds054 /tmp/ds054/derivatives participant \
-                -w /tmp/ds054/work --fs-no-reconall --sloppy --write-graph \
-                --skull-strip-template OASIS30ANTs:res-1 \
-                --output-spaces MNI152Lin MNI152NLin2009cAsym \
-                --mem-gb 4 --ncpus 2 --omp-nthreads 2 -vv \
-                --fs-license-file /tmp/fslicense/license.txt
-
+            bash /tmp/src/smriprep/.circleci/ds054_run.sh
+      - store_artifacts:
+          path: /tmp/ds054/work
+          destination: fasttrack-work
+      - store_artifacts:
+          path: /tmp/ds054/derivatives
+          destination: fasttrack-derivatives
   build_docs:
     docker:
       - image: python:3.7.4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -362,6 +362,18 @@ jobs:
             - build-v2-
           paths:
             - /tmp/docker
+      - restore_cache:
+          keys:
+            - ds005-anat-v6-{{ .Branch }}-{{ epoch }}
+            - ds005-anat-v6-{{ .Branch }}
+            - ds005-anat-v6-master
+            - ds005-anat-v6-
+      - restore_cache:
+          keys:
+            - testdata-v1-{{ .Branch }}-{{ epoch }}
+            - testdata-v1-{{ .Branch }}
+            - testdata-v1-
+
       - run:
           name: Setting up test
           command: |
@@ -499,6 +511,20 @@ jobs:
                 -exec sh -c 'rm -f {}; touch {}' \;
       - store_artifacts:
           path: /tmp/ds005
+
+      - run:
+          name: Check fast track using existing derivatives
+          no_output_timeout: 5m
+          command: |
+            docker run --rm=false -it -v /tmp:/tmp \
+                -e FMRIPREP_DEV=1 -u $(id -u) \
+                poldracklab/smriprep:latest \
+                /tmp/data/ds005 /tmp/ds005/derivatives participant \
+                 -w /tmp/data/ds005/work \
+                --skull-strip-template MNI152NLin2009cAsym:res-2 \
+                --sloppy --write-graph --mem-gb 4 \
+                --ncpus 2 --omp-nthreads 2 -vv \
+                --fs-license-file /tmp/fslicense/license.txt
 
   ds054:
     machine:
@@ -657,6 +683,20 @@ jobs:
                 -exec sh -c 'rm -f {}; touch {}' \;
       - store_artifacts:
           path: /tmp/ds054
+
+      - run:
+          name: Check fast track using existing derivatives (with --fs-no-reconall)
+          no_output_timeout: 5m
+          command: |
+            docker run --rm=false -it -v /tmp:/tmp \
+                -e FMRIPREP_DEV=1 -u $(id -u) \
+                poldracklab/smriprep:latest \
+                /tmp/data/ds054 /tmp/ds054/derivatives participant \
+                -w /tmp/ds054/work --fs-no-reconall --sloppy --write-graph \
+                --skull-strip-template OASIS30ANTs:res-1 \
+                --output-spaces MNI152Lin MNI152NLin2009cAsym \
+                --mem-gb 4 --ncpus 2 --omp-nthreads 2 -vv \
+                --fs-license-file /tmp/fslicense/license.txt
 
   build_docs:
     docker:

--- a/.circleci/ds005_run.sh
+++ b/.circleci/ds005_run.sh
@@ -15,6 +15,7 @@ docker run -it -e FMRIPREP_DEV=1 -u $(id -u) \
     -w /tmp/ds005/work \
     --skull-strip-template MNI152NLin2009cAsym:res-2 \
     --sloppy --mem-gb 4 \
-    --ncpus 2 --omp-nthreads 2 -vv $( cat /tmp/.force ) \
+    --ncpus 2 --omp-nthreads 2 -vv \
     --fs-license-file /tmp/fslicense/license.txt \
-    --fs-subjects-dir /tmp/ds005/freesurfer ${@:1}
+    --fs-subjects-dir /tmp/ds005/freesurfer \
+    ${@:1}

--- a/.circleci/ds005_run.sh
+++ b/.circleci/ds005_run.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+docker run -it -e FMRIPREP_DEV=1 -u $(id -u) \
+    -v /tmp/data:/tmp/data:ro \
+    -v /tmp/fslicense:/tmp/fslicense:ro \
+    -v /tmp/ds005:/tmp/ds005 \
+    -v /tmp/templateflow:/home/smriprep/.cache/templateflow \
+    -v /tmp/src/smriprep/.circleci/nipype.cfg:/home/smriprep/.nipype/nipype.cfg \
+    -e FMRIPREP_DEV=1 -u $(id -u) \
+    -e COVERAGE_FILE=/tmp/ds005/work/.coverage \
+    -e COVERAGE_RCFILE=/src/smriprep/docker/multiproc.coveragerc \
+    --entrypoint=coverage \
+    poldracklab/smriprep:latest \
+    run -m smriprep \
+    /tmp/data/ds005 /tmp/ds005/derivatives participant \
+    -w /tmp/ds005/work \
+    --skull-strip-template MNI152NLin2009cAsym:res-2 \
+    --sloppy --mem-gb 4 \
+    --ncpus 2 --omp-nthreads 2 -vv $( cat /tmp/.force ) \
+    --fs-license-file /tmp/fslicense/license.txt \
+    --fs-subjects-dir /tmp/ds005/freesurfer ${@:1}

--- a/.circleci/ds054_run.sh
+++ b/.circleci/ds054_run.sh
@@ -16,4 +16,5 @@ docker run --rm -it -e FMRIPREP_DEV=1 -u $(id -u) \
     --skull-strip-template OASIS30ANTs:res-1 \
     --output-spaces MNI152Lin MNI152NLin2009cAsym \
     --mem-gb 4 --ncpus 2 --omp-nthreads 2 -vv \
-    --fs-license-file /tmp/fslicense/license.txt
+    --fs-license-file /tmp/fslicense/license.txt \
+    ${@:1}

--- a/.circleci/ds054_run.sh
+++ b/.circleci/ds054_run.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+docker run --rm -it -e FMRIPREP_DEV=1 -u $(id -u) \
+    -v /tmp/data:/tmp/data:ro \
+    -v /tmp/fslicense:/tmp/fslicense:ro \
+    -v /tmp/ds054:/tmp/ds054 \
+    -v /tmp/templateflow:/home/smriprep/.cache/templateflow \
+    -v /tmp/src/smriprep/.circleci/nipype.cfg:/home/smriprep/.nipype/nipype.cfg \
+    -e FMRIPREP_DEV=1 -u $(id -u) \
+    -e COVERAGE_FILE=/tmp/ds054/work/.coverage \
+    -e COVERAGE_RCFILE=/src/smriprep/docker/multiproc.coveragerc \
+    --entrypoint=coverage \
+    poldracklab/smriprep:latest \
+    run -m smriprep \
+    /tmp/data/ds054 /tmp/ds054/derivatives participant \
+    -w /tmp/ds054/work --fs-no-reconall --sloppy \
+    --skull-strip-template OASIS30ANTs:res-1 \
+    --output-spaces MNI152Lin MNI152NLin2009cAsym \
+    --mem-gb 4 --ncpus 2 --omp-nthreads 2 -vv \
+    --fs-license-file /tmp/fslicense/license.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     niworkflows ~= 1.1.7
     numpy
     packaging
-    pybids ~= 0.9.4
+    pybids @ git+https://github.com/oesteban/pybids.git@f20843391439c3fc71849d6a34a1316b5b13dea6
     pyyaml
     templateflow ~= 0.4.2
 test_requires =
@@ -77,6 +77,7 @@ all =
 smriprep =
     VERSION
     data/boilerplate.bib
+    data/io_spec.json
     data/itkIdentityTransform.txt
     data/reports/config.json
     data/reports/report.tpl

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     niworkflows ~= 1.1.7
     numpy
     packaging
-    pybids @ git+https://github.com/oesteban/pybids.git@f20843391439c3fc71849d6a34a1316b5b13dea6
+    pybids >= 0.10.1
     pyyaml
     templateflow ~= 0.4.2
 test_requires =

--- a/smriprep/cli/run.py
+++ b/smriprep/cli/run.py
@@ -118,8 +118,8 @@ def get_parser():
     g_other.add_argument('-w', '--work-dir', action='store', type=Path, default=Path('work'),
                          help='path where intermediate results should be stored')
     g_other.add_argument(
-        '--force-build', action='store_true', default=False,
-        help='')
+        '--fast-track', action='store_true', default=False,
+        help='fast-track the workflow by searching for existing derivatives.')
     g_other.add_argument(
         '--resource-monitor', action='store_true', default=False,
         help='enable Nipype\'s resource monitoring to keep track of memory and CPU usage')
@@ -409,7 +409,7 @@ def build_workflow(opts, retval):
     # Build main workflow
     retval['workflow'] = init_smriprep_wf(
         debug=opts.sloppy,
-        force_build=opts.force_build,
+        fast_track=opts.fast_track,
         freesurfer=opts.run_reconall,
         fs_subjects_dir=opts.fs_subjects_dir,
         hires=opts.hires,

--- a/smriprep/cli/run.py
+++ b/smriprep/cli/run.py
@@ -118,6 +118,9 @@ def get_parser():
     g_other.add_argument('-w', '--work-dir', action='store', type=Path, default=Path('work'),
                          help='path where intermediate results should be stored')
     g_other.add_argument(
+        '--force-build', action='store_true', default=False,
+        help='')
+    g_other.add_argument(
         '--resource-monitor', action='store_true', default=False,
         help='enable Nipype\'s resource monitoring to keep track of memory and CPU usage')
     g_other.add_argument(
@@ -406,6 +409,7 @@ def build_workflow(opts, retval):
     # Build main workflow
     retval['workflow'] = init_smriprep_wf(
         debug=opts.sloppy,
+        force_build=opts.force_build,
         freesurfer=opts.run_reconall,
         fs_subjects_dir=opts.fs_subjects_dir,
         hires=opts.hires,

--- a/smriprep/data/io_spec.json
+++ b/smriprep/data/io_spec.json
@@ -1,0 +1,84 @@
+{
+  "queries": {
+    "baseline": {
+      "preproc": {
+        "datatype": "anat",
+        "desc": "preproc",
+        "suffix": "T1w"
+      },
+      "mask": {
+        "datatype": "anat",
+        "desc": "brain",
+        "suffix": "mask"
+      },
+      "dseg": {
+        "datatype": "anat",
+        "suffix": "dseg"
+      },
+      "tpms": {
+        "datatype": "anat",
+        "label": [ "CSF", "WM", "GM"],
+        "suffix": "probseg"
+      }
+    },
+    "std_xfms": {
+      "anat2std_xfm": {
+        "datatype": "anat",
+        "extension": "h5",
+        "from": "T1w",
+        "to": [],
+        "suffix": "xfm",
+        "mode": "image"
+      },
+      "std2anat_xfm": {
+        "datatype": "anat",
+        "extension": "h5",
+        "from": [],
+        "to": "T1w",
+        "suffix": "xfm",
+        "mode": "image"
+      }
+    },
+    "surfaces": {
+      "aseg": {
+        "datatype": "anat",
+        "desc": "aseg",
+        "suffix": "dseg"
+      },
+      "aparcaseg": {
+        "datatype": "anat",
+        "desc": "aparcaseg",
+        "suffix": "dseg"
+      },
+      "anat2fsnative_xfm": {
+        "datatype": "anat",
+        "from": "T1w",
+        "to": "fsnative",
+        "extension": "txt",
+        "suffix": "xfm",
+        "mode": "image"
+      },
+      "fsnative2anat_xfm": {
+        "datatype": "anat",
+        "from": "fsnative",
+        "to": "T1w",
+        "extension": "txt",
+        "suffix": "xfm",
+        "mode": "image"
+      },
+      "surfaces": {
+        "datatype": "anat",
+        "hemi": ["L", "R"],
+        "extension": "surf.gii",
+        "suffix": [ "inflated", "midthickness", "pial", "smoothwm"]
+      }
+    }
+  },
+  "patterns": [
+    "sub-{subject}[/ses-{session}]/{datatype<anat>|anat}/sub-{subject}[_ses-{session}][_acq-{acquisition}][_ce-{ceagent}][_rec-{reconstruction}][_space-{space}][_desc-{desc}]_{suffix<T1w|T2w|T1rho|T1map|T2map|T2star|FLAIR|FLASH|PDmap|PD|PDT2|dseg|inplaneT[12]|angio>}.{extension<nii|nii.gz|json>|nii.gz}",
+    "sub-{subject}[/ses-{session}]/{datatype<anat>|anat}/sub-{subject}[_ses-{session}][_acq-{acquisition}][_ce-{ceagent}][_rec-{reconstruction}]_from-{from}_to-{to}_mode-{mode<image|points>|image}_{suffix<xfm>|xfm}.{extension<txt|h5>}",
+    "sub-{subject}[/ses-{session}]/{datatype<anat>|anat}/sub-{subject}[_ses-{session}][_acq-{acquisition}][_ce-{ceagent}][_rec-{reconstruction}]_hemi-{hemi<L|R>}_{suffix<wm|smoothwm|pial|midthickness|inflated|vinflated|sphere|flat>}.{extension<surf.gii>}",
+    "sub-{subject}[/ses-{session}]/{datatype<anat>|anat}/sub-{subject}[_ses-{session}][_acq-{acquisition}][_ce-{ceagent}][_rec-{reconstruction}][_space-{space}]_desc-{desc}_{suffix<mask>|mask}.{extension<nii|nii.gz|json>|nii.gz}",
+    "sub-{subject}[/ses-{session}]/{datatype<anat>|anat}/sub-{subject}[_ses-{session}][_acq-{acquisition}][_ce-{ceagent}][_rec-{reconstruction}][_space-{space}]_label-{label}[_desc-{desc}]_{suffix<probseg>|probseg}.{extension<nii|nii.gz|json>|nii.gz}"
+  ]
+}

--- a/smriprep/utils/bids.py
+++ b/smriprep/utils/bids.py
@@ -33,7 +33,7 @@ def collect_derivatives(layout, subject_id, output_spaces, freesurfer):
         derivs_cache = defaultdict(list, derivs_cache)
 
     for space in derivs_cache['template']:
-        derivs_cache['std_t1w_preproc'] += layout.get(
+        derivs_cache['std_t1w'] += layout.get(
             desc='preproc', space=space, suffix='T1w', **common_entities)
         derivs_cache['std_mask'] += layout.get(
             desc='brain', suffix='mask', space=space, **common_entities)

--- a/smriprep/utils/bids.py
+++ b/smriprep/utils/bids.py
@@ -2,78 +2,154 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Utilities to handle BIDS inputs."""
 from collections import defaultdict
+from pathlib import Path
+from json import loads
+from pkg_resources import resource_filename as pkgrf
+from bids.layout.writing import build_path
 
 
-def collect_derivatives(layout, subject_id, output_spaces, freesurfer):
+def predict_derivatives(subject_id, output_spaces, freesurfer):
+    """
+    Generate a list of the files that should be found in the output folder.
+
+    The prediction of outputs serves two purposes:
+
+      * Anticipates the set of outputs that will be generated.
+      * Informs the decision of whether the workflow should be staged or some
+        sections can be skip.
+
+    Parameters
+    ----------
+    subject_id : :obj:`str`
+        A subject id
+    output_spaces : :obj:`list`
+        TemplateFlow identifiers of the requested output spaces
+    freesurfer : :obj:`bool`
+        Whether the ``--fs-no-reconall`` flag was used.
+
+    Examples
+    --------
+    >>> predict_derivatives('01', ['MNI152NLin2009cAsym'], False)
+    ['sub-01/anat/sub-01_desc-brain_mask.nii.gz',
+     'sub-01/anat/sub-01_desc-preproc_T1w.nii.gz',
+     'sub-01/anat/sub-01_dseg.nii.gz',
+     'sub-01/anat/sub-01_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5',
+     'sub-01/anat/sub-01_from-T1w_to-MNI152NLin2009cAsym_mode-image_xfm.h5',
+     'sub-01/anat/sub-01_label-CSF_probseg.nii.gz',
+     'sub-01/anat/sub-01_label-GM_probseg.nii.gz',
+     'sub-01/anat/sub-01_label-WM_probseg.nii.gz',
+     'sub-01/anat/sub-01_space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz',
+     'sub-01/anat/sub-01_space-MNI152NLin2009cAsym_desc-preproc_T1w.nii.gz',
+     'sub-01/anat/sub-01_space-MNI152NLin2009cAsym_dseg.nii.gz',
+     'sub-01/anat/sub-01_space-MNI152NLin2009cAsym_label-CSF_probseg.nii.gz',
+     'sub-01/anat/sub-01_space-MNI152NLin2009cAsym_label-GM_probseg.nii.gz',
+     'sub-01/anat/sub-01_space-MNI152NLin2009cAsym_label-WM_probseg.nii.gz']
+
+    """
+    spec = loads(Path(pkgrf('smriprep', 'data/io_spec.json')).read_text())
+
+    def _normalize_q(query, space=None):
+        query = query.copy()
+        query['subject'] = subject_id
+        if space is not None:
+            query['space'] = space
+        if 'from' in query and not query['from']:
+            query['from'] = output_spaces
+        if 'to' in query and not query['to']:
+            query['to'] = output_spaces
+        return query
+
+    queries = [_normalize_q(q, space=None)
+               for q in spec['queries']['baseline'].values()]
+
+    queries += [_normalize_q(q, space=s) for s in output_spaces
+                for q in spec['queries']['baseline'].values()]
+    queries += [_normalize_q(q) for q in spec['queries']['std_xfms'].values()]
+    if freesurfer:
+        queries += [_normalize_q(q)
+                    for q in spec['queries']['surfaces'].values()]
+
+    output = []
+    for q in queries:
+        paths = build_path(q, spec['patterns'])
+        if isinstance(paths, str):
+            output.append(paths)
+        elif paths:
+            output += paths
+
+    return sorted(output)
+
+
+def collect_derivatives(derivatives_dir, subject_id, std_spaces, freesurfer,
+                        spec=None, patterns=None):
     """Gather existing derivatives and compose a cache."""
-    if not layout.get(scope='derivatives'):
-        raise ValueError('Derivatives folder seems empty.')
+    if spec is None or patterns is None:
+        _spec, _patterns = tuple(
+            loads(Path(pkgrf('smriprep', 'data/io_spec.json')).read_text()).values())
 
-    common_entities = {
-        'subject': subject_id,
-        'datatype': 'anat',
-        'extension': ['.nii', '.nii.gz'],
-        'return_type': 'file',
-    }
-    spaces = layout.get_spaces(datatype='anat')
-    derivs_cache = {
-        'template': [s for s in output_spaces if s in spaces],
-        't1w_preproc': layout.get(
-            desc='preproc', suffix='T1w', space=None, **common_entities)[0],
-        't1w_mask': layout.get(
-            desc='brain', suffix='mask', space=None, **common_entities)[0],
-        't1w_dseg': layout.get(
-            desc=None, suffix='dseg', space=None, **common_entities)[0],
-        't1w_tpms': layout.get(
-            desc=None, label=['CSF', 'WM', 'GM'], suffix='probseg', space=None,
-            **common_entities),
-    }
+        if spec is None:
+            spec = _spec
+        if patterns is None:
+            patterns = _patterns
 
-    if derivs_cache['template']:
-        derivs_cache = defaultdict(list, derivs_cache)
+    derivs_cache = defaultdict(list, {})
+    derivatives_dir = Path(derivatives_dir)
 
-    for space in derivs_cache['template']:
-        derivs_cache['std_t1w'] += layout.get(
-            desc='preproc', space=space, suffix='T1w', **common_entities)
-        derivs_cache['std_mask'] += layout.get(
-            desc='brain', suffix='mask', space=space, **common_entities)
-        derivs_cache['std_dseg'] += layout.get(
-            desc=None, suffix='dseg', space=space, **common_entities)
-        derivs_cache['std_tpms'] += layout.get(
-            desc=None, label=['CSF', 'WM', 'GM'], suffix='probseg', space=space,
-            **common_entities)
+    def _check_item(item):
+        if not item:
+            return None
 
-        # Retrieve spatial transforms
-        xfm_query = common_entities.copy()
-        xfm_query.update({'from': 'T1w', 'to': space, 'extension': '.h5',
-                          'suffix': 'xfm', 'mode': 'image'})
-        derivs_cache['anat2std_xfm'] += layout.get(**xfm_query)
+        if isinstance(item, str):
+            item = [item]
 
-        xfm_query.update({'to': 'T1w', 'from': space})
-        derivs_cache['std2anat_xfm'] += layout.get(**xfm_query)
+        result = []
+        for i in item:
+            if not (derivatives_dir / i).exists():
+                i = i.rstrip('.gz')
+                if not (derivatives_dir / i).exists():
+                    return None
+            result.append(str(derivatives_dir / i))
+
+        return result
+
+    for space in [None] + std_spaces:
+        for k, q in spec['baseline'].items():
+            q['subject'] = subject_id
+            if space is not None:
+                q['space'] = space
+            item = _check_item(build_path(q, patterns, strict=True))
+            if not item:
+                return None
+
+            if space:
+                derivs_cache["std_%s" % k] += item
+            else:
+                derivs_cache["t1w_%s" % k] = item[0]
+
+    for space in std_spaces:
+        for k, q in spec['std_xfms'].items():
+            q['subject'] = subject_id
+            q['from'] = q['from'] or space
+            q['to'] = q['to'] or space
+            item = _check_item(build_path(q, patterns))
+            if not item:
+                return None
+            derivs_cache[k] += item
 
     derivs_cache = dict(derivs_cache)  # Back to a standard dictionary
 
     if freesurfer:
-        derivs_cache['t1w_aseg'] = layout.get(
-            desc='aseg', suffix='dseg', space=None, **common_entities)[0]
-        derivs_cache['t1w_aparc'] = layout.get(
-            desc='aparcaseg', suffix='dseg', space=None, **common_entities)[0]
+        for k, q in spec['surfaces'].items():
+            q['subject'] = subject_id
+            item = _check_item(build_path(q, patterns))
+            if not item:
+                return None
 
-        fs_query = common_entities.copy()
-        fs_query.update({'from': 'T1w', 'to': 'fsnative', 'extension': '.txt',
-                         'suffix': 'xfm', 'mode': 'image'})
-        derivs_cache['t1w2fsnative_xfm'] = layout.get(**fs_query)[0]
-        fs_query.update({'from': 'fsnative', 'to': 'T1w'})
-        derivs_cache['fsnative2t1w_xfm'] = layout.get(**fs_query)[0]
+            if len(item) == 1:
+                item = item[0]
+            derivs_cache[k] = item
 
-        common_entities['extension'] = '.surf.gii'
-        derivs_cache['surfaces'] = layout.get(**common_entities)
-
-    for k, v in derivs_cache.items():
-        if not v:
-            raise ValueError('Empty entry "%s" found in the collected derivatives.' % k)
-
+    derivs_cache['template'] = std_spaces
     return derivs_cache
 
 

--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -3,6 +3,7 @@
 """Anatomical reference preprocessing workflows."""
 from pkg_resources import resource_filename as pkgr
 
+from nipype import logging
 from nipype.pipeline import engine as pe
 from nipype.interfaces import (
     utility as niu,
@@ -27,6 +28,8 @@ from .norm import init_anat_norm_wf
 from .outputs import init_anat_reports_wf, init_anat_derivatives_wf
 from .surfaces import init_surface_recon_wf
 
+LOGGER = logging.getLogger('nipype.workflow')
+
 
 def init_anat_preproc_wf(
         bids_root,
@@ -40,6 +43,7 @@ def init_anat_preproc_wf(
         skull_strip_template,
         spaces,
         debug=False,
+        existing_derivatives=None,
         name='anat_preproc_wf',
         skull_strip_fixed_seed=False
 ):
@@ -172,7 +176,53 @@ def init_anat_preproc_wf(
 : """
     desc += """\
 A total of {num_t1w} T1-weighted (T1w) images were found within the input
-BIDS dataset.
+BIDS dataset.""".format(num_t1w=num_t1w)
+
+    inputnode = pe.Node(
+        niu.IdentityInterface(fields=['t1w', 't2w', 'roi', 'flair', 'subjects_dir', 'subject_id']),
+        name='inputnode')
+    outputnode = pe.Node(niu.IdentityInterface(
+        fields=[
+            't1w_preproc', 't1w_mask', 't1w_dseg', 't1w_tpms',  # T1w space
+            'std_t1w_preproc', 'std_mask', 'std_dseg', 'std_tpms',  # Standard spaces
+            'template', 'anat2std_xfm', 'std2anat_xfm',  # Standard spaces (misc)
+            'subjects_dir', 'subject_id', 'surfaces',  # Freesurfer
+            't1w_aseg', 't1w_aparc', 't1w2fsnative_xfm', 'fsnative2t1w_xfm',  # Freesurfer
+        ]),
+        name='outputnode')
+
+    if existing_derivatives is not None:
+        _needed_inputs = ['t1w_preproc', 't1w_mask', 't1w_dseg', 't1w_tpms',
+                          'std_t1w_preproc', 'std_mask', 'std_dseg', 'std_tpms',
+                          'template', 'anat2std_xfm', 'std2anat_xfm']
+        if freesurfer:
+            _needed_inputs += ['surfaces', 't1w_aseg', 't1w_aparc', 't1w2fsnative_xfm']
+
+        missing = set(_needed_inputs) - set(existing_derivatives.keys())
+        if missing:
+            LOGGER.warning("Failed to set prior derivatives. Missing fields: %s.",
+                           ', '.join(missing))
+        else:
+            LOGGER.log(25, "Anatomical workflow will reuse prior derivatives found in the "
+                       "output folder (%s).", output_dir)
+            desc += """
+Anatomical preprocessing was reused from previously existing derivative objects.\n"""
+            workflow.__desc__ = desc
+
+            for field in _needed_inputs:
+                setattr(outputnode.inputs, field, existing_derivatives[field])
+
+            if freesurfer:
+                workflow.connect([
+                    (inputnode, outputnode, [('subjects_dir', 'subjects_dir'),
+                                             ('subject_id', 'subject_id')]),
+                ])
+            else:  # need to add manually
+                workflow.add_nodes([inputnode, outputnode])
+            return workflow
+
+    # The workflow is not cached.
+    desc += """
 All of them were corrected for intensity non-uniformity (INU)
 """ if num_t1w > 1 else """\
 The T1-weighted (T1w) image was corrected for intensity non-uniformity (INU)
@@ -327,9 +377,6 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823,
             ('std_mask', 'inputnode.std_mask'),
             ('std_dseg', 'inputnode.std_dseg'),
             ('std_tpms', 'inputnode.std_tpms'),
-            ('t1w2fsnative_xfm', 'inputnode.t1w2fsnative_xfm'),
-            ('fsnative2t1w_xfm', 'inputnode.fsnative2t1w_xfm'),
-            ('surfaces', 'inputnode.surfaces'),
         ]),
     ])
 
@@ -377,6 +424,11 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823,
         (surface_recon_wf, anat_derivatives_wf, [
             ('outputnode.out_aseg', 'inputnode.t1w_fs_aseg'),
             ('outputnode.out_aparc', 'inputnode.t1w_fs_aparc'),
+        ]),
+        (outputnode, anat_derivatives_wf, [
+            ('t1w2fsnative_xfm', 'inputnode.t1w2fsnative_xfm'),
+            ('fsnative2t1w_xfm', 'inputnode.fsnative2t1w_xfm'),
+            ('surfaces', 'inputnode.surfaces'),
         ]),
     ])
 

--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -170,6 +170,9 @@ def init_anat_preproc_wf(
     * :py:func:`~smriprep.workflows.surfaces.init_surface_recon_wf`
 
     """
+    vol_spaces = [k for k in output_spaces.keys()
+                  if not k.startswith('fs')]
+
     workflow = Workflow(name=name)
     desc = """Anatomical data preprocessing
 
@@ -184,17 +187,36 @@ BIDS dataset.""".format(num_t1w=num_t1w)
     outputnode = pe.Node(niu.IdentityInterface(
         fields=[
             't1w_preproc', 't1w_mask', 't1w_dseg', 't1w_tpms',  # T1w space
-            'std_t1w_preproc', 'std_mask', 'std_dseg', 'std_tpms',  # Standard spaces
+            'std_t1w', 'std_mask', 'std_dseg', 'std_tpms',  # Standard spaces
             'template', 'anat2std_xfm', 'std2anat_xfm',  # Standard spaces (misc)
             'subjects_dir', 'subject_id', 'surfaces',  # Freesurfer
             't1w_aseg', 't1w_aparc', 't1w2fsnative_xfm', 'fsnative2t1w_xfm',  # Freesurfer
         ]),
         name='outputnode')
 
+    # Connect reportlets workflows
+    anat_reports_wf = init_anat_reports_wf(
+        freesurfer=freesurfer,
+        reportlets_dir=reportlets_dir,
+    )
+    workflow.connect([
+        # Connect reportlets
+        (inputnode, anat_reports_wf, [
+            (('t1w', fix_multi_T1w_source_name), 'inputnode.source_file')]),
+        (outputnode, anat_reports_wf, [
+            ('t1w_preproc', 'inputnode.t1w_preproc'),
+            ('t1w_mask', 'inputnode.t1w_mask'),
+            ('t1w_dseg', 'inputnode.t1w_dseg')]),
+        (inputnode, anat_reports_wf, [
+            (('t1w', fix_multi_T1w_source_name), 'inputnode.source_file')]),
+        (outputnode, anat_reports_wf, [
+            ('std_t1w', 'inputnode.std_t1w'),
+            ('std_mask', 'inputnode.std_mask')]),
+    ])
+
     if existing_derivatives is not None:
-        _needed_inputs = ['t1w_preproc', 't1w_mask', 't1w_dseg', 't1w_tpms',
-                          'std_t1w_preproc', 'std_mask', 'std_dseg', 'std_tpms',
-                          'template', 'anat2std_xfm', 'std2anat_xfm']
+        _needed_inputs = ['t1w_preproc', 't1w_mask', 't1w_dseg', 't1w_tpms']
+
         if freesurfer:
             _needed_inputs += ['surfaces', 't1w_aseg', 't1w_aparc', 't1w2fsnative_xfm']
 
@@ -212,13 +234,24 @@ Anatomical preprocessing was reused from previously existing derivative objects.
             for field in _needed_inputs:
                 setattr(outputnode.inputs, field, existing_derivatives[field])
 
+            anat_reports_wf.get_node('inputnode').iterables = [
+                ('template', [(v, output_spaces[v]) for v in vol_spaces])]
+
+            t1w_ref_dimensions = pe.Node(TemplateDimensions(),
+                                         name='t1w_ref_dimensions')
+            workflow.connect([
+                (inputnode, t1w_ref_dimensions, [('t1w', 't1w_list')]),
+                (t1w_ref_dimensions, anat_reports_wf, [
+                    ('out_report', 'inputnode.t1w_conform_report')]),
+            ])
             if freesurfer:
                 workflow.connect([
                     (inputnode, outputnode, [('subjects_dir', 'subjects_dir'),
                                              ('subject_id', 'subject_id')]),
+                    (inputnode, anat_reports_wf, [
+                        ('subjects_dir', 'inputnode.subjects_dir'),
+                        ('subject_id', 'inputnode.subject_id')]),
                 ])
-            else:  # need to add manually
-                workflow.add_nodes([inputnode, outputnode])
             return workflow
 
     # The workflow is not cached.
@@ -309,6 +342,8 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823,
             ('outputnode.t1w_realign_xfm', 't1w_ref_xfms')]),
         (buffernode, outputnode, [('t1w_brain', 't1w_brain'),
                                   ('t1w_mask', 't1w_mask')]),
+        (anat_template_wf, anat_reports_wf, [
+            ('outputnode.out_report', 'inputnode.t1w_conform_report')]),
         # Steps 2, 3 and 4
         (inputnode, anat_norm_wf, [
             (('t1w', fix_multi_T1w_source_name), 'inputnode.orig_t1w'),
@@ -332,12 +367,11 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823,
             ('outputnode.anat2std_xfm', 'joint_anat2std_xfm'),
             ('outputnode.std2anat_xfm', 'joint_std2anat_xfm'),
         ]),
+        (anat_norm_wf, anat_reports_wf, [
+            ('poutputnode.template', 'inputnode.template')]),
     ])
 
     # Write outputs ############################################3
-    anat_reports_wf = init_anat_reports_wf(
-        reportlets_dir=reportlets_dir, freesurfer=freesurfer)
-
     anat_derivatives_wf = init_anat_derivatives_wf(
         bids_root=bids_root,
         freesurfer=freesurfer,
@@ -346,20 +380,6 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823,
     )
 
     workflow.connect([
-        # Connect reportlets
-        (inputnode, anat_reports_wf, [
-            (('t1w', fix_multi_T1w_source_name), 'inputnode.source_file')]),
-        (anat_template_wf, anat_reports_wf, [
-            ('outputnode.out_report', 'inputnode.t1w_conform_report')]),
-        (outputnode, anat_reports_wf, [
-            ('t1w_preproc', 'inputnode.t1w_preproc'),
-            ('t1w_dseg', 'inputnode.t1w_dseg'),
-            ('t1w_mask', 'inputnode.t1w_mask'),
-            ('std_t1w', 'inputnode.std_t1w'),
-            ('std_mask', 'inputnode.std_mask')]),
-        (anat_norm_wf, anat_reports_wf, [
-            ('poutputnode.template', 'inputnode.template'),
-            ('poutputnode.template_spec', 'inputnode.template_spec')]),
         # Connect derivatives
         (anat_template_wf, anat_derivatives_wf, [
             ('outputnode.t1w_valid_list', 'inputnode.source_files')]),

--- a/smriprep/workflows/base.py
+++ b/smriprep/workflows/base.py
@@ -24,6 +24,7 @@ from .anatomical import init_anat_preproc_wf
 
 def init_smriprep_wf(
     debug,
+    force_build,
     freesurfer,
     fs_subjects_dir,
     hires,
@@ -59,6 +60,7 @@ def init_smriprep_wf(
             from niworkflows.utils.spaces import SpatialReferences, Reference
             wf = init_smriprep_wf(
                 debug=False,
+                force_build=True,
                 freesurfer=True,
                 fs_subjects_dir=None,
                 hires=True,
@@ -80,6 +82,8 @@ def init_smriprep_wf(
     ----------
     debug : :obj:`bool`
         Enable debugging outputs
+    force_build : :obj:`bool`
+        Do not fast-track the workflow by searching for existing derivatives.
     freesurfer : :obj:`bool`
         Enable FreeSurfer surface reconstruction (may increase runtime)
     fs_subjects_dir : os.PathLike or None
@@ -134,6 +138,7 @@ def init_smriprep_wf(
         single_subject_wf = init_single_subject_wf(
             debug=debug,
             freesurfer=freesurfer,
+            force_build=force_build,
             hires=hires,
             layout=layout,
             longitudinal=longitudinal,
@@ -166,6 +171,7 @@ def init_smriprep_wf(
 def init_single_subject_wf(
     debug,
     freesurfer,
+    force_build,
     hires,
     layout,
     longitudinal,
@@ -295,6 +301,16 @@ to workflows in *sMRIPrep*'s documentation]\
 
 """
 
+    deriv_cache = None
+    if not force_build:
+        from ..utils.bids import collect_derivatives
+        deriv_cache = {}
+        layout.add_derivatives(os.path.join(output_dir, 'smriprep'))
+        try:
+            deriv_cache = collect_derivatives(layout, subject_id, output_spaces, freesurfer)
+        except (IndexError, ValueError):
+            pass
+
     inputnode = pe.Node(niu.IdentityInterface(fields=['subjects_dir']),
                         name='inputnode')
 
@@ -325,6 +341,7 @@ to workflows in *sMRIPrep*'s documentation]\
     anat_preproc_wf = init_anat_preproc_wf(
         bids_root=layout.root,
         debug=debug,
+        existing_derivatives=deriv_cache,
         freesurfer=freesurfer,
         hires=hires,
         longitudinal=longitudinal,

--- a/smriprep/workflows/base.py
+++ b/smriprep/workflows/base.py
@@ -25,7 +25,7 @@ from .anatomical import init_anat_preproc_wf
 
 def init_smriprep_wf(
     debug,
-    force_build,
+    fast_track,
     freesurfer,
     fs_subjects_dir,
     hires,
@@ -61,7 +61,7 @@ def init_smriprep_wf(
             from niworkflows.utils.spaces import SpatialReferences, Reference
             wf = init_smriprep_wf(
                 debug=False,
-                force_build=True,
+                fast_track=False,
                 freesurfer=True,
                 fs_subjects_dir=None,
                 hires=True,
@@ -83,8 +83,8 @@ def init_smriprep_wf(
     ----------
     debug : :obj:`bool`
         Enable debugging outputs
-    force_build : :obj:`bool`
-        Do not fast-track the workflow by searching for existing derivatives.
+    fast_track : :obj:`bool`
+        Fast-track the workflow by searching for existing derivatives.
     freesurfer : :obj:`bool`
         Enable FreeSurfer surface reconstruction (may increase runtime)
     fs_subjects_dir : os.PathLike or None
@@ -139,7 +139,7 @@ def init_smriprep_wf(
         single_subject_wf = init_single_subject_wf(
             debug=debug,
             freesurfer=freesurfer,
-            force_build=force_build,
+            fast_track=fast_track,
             hires=hires,
             layout=layout,
             longitudinal=longitudinal,
@@ -172,7 +172,7 @@ def init_smriprep_wf(
 def init_single_subject_wf(
     debug,
     freesurfer,
-    force_build,
+    fast_track,
     hires,
     layout,
     longitudinal,
@@ -211,7 +211,7 @@ def init_single_subject_wf(
             wf = init_single_subject_wf(
                 debug=False,
                 freesurfer=True,
-                force_build=True,
+                fast_track=False,
                 hires=True,
                 layout=BIDSLayout('.'),
                 longitudinal=False,
@@ -233,8 +233,8 @@ def init_single_subject_wf(
         Enable debugging outputs
     freesurfer : :obj:`bool`
         Enable FreeSurfer surface reconstruction (may increase runtime)
-    force_build : :obj:`bool`
-        If ``True``, skip the attempt to collect previously run derivatives.
+    fast_track : :obj:`bool`
+        If ``True``, attempt to collect previously run derivatives.
     hires : :obj:`bool`
         Enable sub-millimeter preprocessing in FreeSurfer
     layout : BIDSLayout object
@@ -306,7 +306,7 @@ to workflows in *sMRIPrep*'s documentation]\
 """
 
     deriv_cache = None
-    if not force_build:
+    if fast_track:
         from ..utils.bids import collect_derivatives
         std_spaces = spaces.get_spaces(nonstandard=False, dim=(3,))
         deriv_cache = collect_derivatives(

--- a/smriprep/workflows/base.py
+++ b/smriprep/workflows/base.py
@@ -3,6 +3,7 @@
 """*sMRIPrep* base processing workflows."""
 import sys
 import os
+from pathlib import Path
 from copy import deepcopy
 
 from nipype import __version__ as nipype_ver
@@ -210,6 +211,7 @@ def init_single_subject_wf(
             wf = init_single_subject_wf(
                 debug=False,
                 freesurfer=True,
+                force_build=True,
                 hires=True,
                 layout=BIDSLayout('.'),
                 longitudinal=False,
@@ -231,6 +233,8 @@ def init_single_subject_wf(
         Enable debugging outputs
     freesurfer : :obj:`bool`
         Enable FreeSurfer surface reconstruction (may increase runtime)
+    force_build : :obj:`bool`
+        If ``True``, skip the attempt to collect previously run derivatives.
     hires : :obj:`bool`
         Enable sub-millimeter preprocessing in FreeSurfer
     layout : BIDSLayout object
@@ -304,12 +308,9 @@ to workflows in *sMRIPrep*'s documentation]\
     deriv_cache = None
     if not force_build:
         from ..utils.bids import collect_derivatives
-        deriv_cache = {}
-        layout.add_derivatives(os.path.join(output_dir, 'smriprep'))
-        try:
-            deriv_cache = collect_derivatives(layout, subject_id, output_spaces, freesurfer)
-        except (IndexError, ValueError):
-            pass
+        std_spaces = spaces.get_spaces(nonstandard=False, dim=(3,))
+        deriv_cache = collect_derivatives(
+            Path(output_dir) / 'smriprep', subject_id, std_spaces, freesurfer)
 
     inputnode = pe.Node(niu.IdentityInterface(fields=['subjects_dir']),
                         name='inputnode')

--- a/smriprep/workflows/outputs.py
+++ b/smriprep/workflows/outputs.py
@@ -11,7 +11,7 @@ from niworkflows.interfaces.freesurfer import PatchedLTAConvert as LTAConvert
 from ..interfaces import DerivativesDataSink
 
 
-def init_anat_reports_wf(reportlets_dir, freesurfer,
+def init_anat_reports_wf(freesurfer, reportlets_dir,
                          name='anat_reports_wf'):
     """Set up a battery of datasinks to store reports in the right location."""
     from niworkflows.interfaces import SimpleBeforeAfter
@@ -46,7 +46,6 @@ def init_anat_reports_wf(reportlets_dir, freesurfer,
                               ('t1w_mask', 'in_mask'),
                               ('t1w_dseg', 'in_rois')]),
         (seg_rpt, ds_t1w_dseg_mask_report, [('out_report', 'in_file')]),
-
     ])
 
     # Generate reportlets showing spatial normalization

--- a/smriprep/workflows/outputs.py
+++ b/smriprep/workflows/outputs.py
@@ -22,13 +22,17 @@ def init_anat_reports_wf(freesurfer, reportlets_dir,
 
     inputfields = ['source_file', 't1w_conform_report',
                    't1w_preproc', 't1w_dseg', 't1w_mask',
-                   'template', 'template_spec', 'std_t1w', 'std_mask',
+                   'template', 'std_t1w', 'std_mask',
                    'subject_id', 'subjects_dir']
     inputnode = pe.Node(niu.IdentityInterface(fields=inputfields),
                         name='inputnode')
 
     seg_rpt = pe.Node(ROIsPlot(colors=['magenta', 'b'], levels=[1.5, 2.5]),
                       name='seg_rpt')
+
+    t1w_conform_check = pe.Node(niu.Function(
+        function=_empty_report),
+        name='t1w_conform_check', run_without_submitting=True)
 
     ds_t1w_conform_report = pe.Node(
         DerivativesDataSink(base_directory=reportlets_dir, desc='conform', keep_dtype=True),
@@ -39,8 +43,9 @@ def init_anat_reports_wf(freesurfer, reportlets_dir,
         name='ds_t1w_dseg_mask_report', run_without_submitting=True)
 
     workflow.connect([
-        (inputnode, ds_t1w_conform_report, [('source_file', 'source_file'),
-                                            ('t1w_conform_report', 'in_file')]),
+        (inputnode, t1w_conform_check, [('t1w_conform_report', 'in_file')]),
+        (t1w_conform_check, ds_t1w_conform_report, [('out', 'in_file')]),
+        (inputnode, ds_t1w_conform_report, [('source_file', 'source_file')]),
         (inputnode, ds_t1w_dseg_mask_report, [('source_file', 'source_file')]),
         (inputnode, seg_rpt, [('t1w_preproc', 'in_file'),
                               ('t1w_mask', 'in_mask'),
@@ -63,8 +68,7 @@ def init_anat_reports_wf(freesurfer, reportlets_dir,
         name='ds_std_t1w_report', run_without_submitting=True)
 
     workflow.connect([
-        (inputnode, tf_select, [(('template', _drop_cohort), 'template'),
-                                ('template_spec', 'template_spec')]),
+        (inputnode, tf_select, [('template', 'template')]),
         (inputnode, norm_rpt, [('template', 'before_label')]),
         (inputnode, norm_msk, [('std_t1w', 'after'),
                                ('std_mask', 'after_mask')]),
@@ -111,7 +115,9 @@ def init_anat_derivatives_wf(bids_root, freesurfer, num_t1w, output_dir,
                     't1w_fs_aseg', 't1w_fs_aparc']),
         name='inputnode')
 
-    t1w_name = pe.Node(niu.Function(function=fix_multi_T1w_source_name), name='t1w_name')
+    t1w_name = pe.Node(niu.Function(
+        function=fix_multi_T1w_source_name),
+        name='t1w_name', run_without_submitting=True)
     raw_sources = pe.Node(niu.Function(function=_bids_relative), name='raw_sources')
     raw_sources.inputs.bids_root = bids_root
 
@@ -333,3 +339,16 @@ def _drop_cohort(in_template):
 
 def _fmt_cohort(in_template):
     return in_template.replace(':', '_')
+
+
+def _empty_report(in_file=None):
+    from pathlib import Path
+    from nipype.interfaces.base import isdefined
+    if in_file is not None and isdefined(in_file):
+        return in_file
+
+    out_file = Path('tmp-report.html').absolute()
+    out_file.write_text("""\
+                <h4 class="elem-title">A previously computed T1w template was provided.</h4>
+""")
+    return str(out_file)

--- a/smriprep/workflows/outputs.py
+++ b/smriprep/workflows/outputs.py
@@ -279,7 +279,6 @@ def init_anat_derivatives_wf(bids_root, freesurfer, num_t1w, output_dir,
         (t1w_name, ds_t1w_fsaseg, [('out', 'source_file')]),
         (t1w_name, ds_t1w_fsparc, [('out', 'source_file')]),
     ])
-
     return workflow
 
 


### PR DESCRIPTION
## Summary
These changes modify the workflow construction function ``init_anat_preproc_wf`` to add a checkpoint on the new named argument ``existing_derivatives`` at the beginning of the process.
When ``existing_derivatives`` is a dictionary containing all the anatomical derivatives to be computed, then the workflow is short-cut and only the reportlets are re-generated.

## Changes

- [x] Implementation of the fast-track.
- [x] New reportlets generation

Other changes in this PR include:
- [x] Boilerplate on the smriprep executable to populate ``existing_derivatives`` that may serve as pattern reference to include this characteristic in fmriprep and dmriprep. The boilerplate includes a new ``--fast-track`` argument to smriprep's command line that forces the check on existing derivatives.
- [x] A new ``smriprep.utils.bids.collect_derivatives`` function that populates ``existing_derivatives``, which can (should) be imported to use the feature in f/dMRIPrep.

## Related issues
Supersedes #107.
Closes #105.