### PR TITLE
MAINT: bump dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,12 +25,12 @@ install_requires =
     matplotlib >= 2.2.0
     nibabel >= 3.0.1
     nipype >= 1.3.1
-    niworkflows ~= 1.1.7
+    niworkflows >= 1.2.0rc1, < 1.3
     numpy
     packaging
-    pybids >= 0.9.4
+    pybids >= 0.10.2
     pyyaml
-    templateflow >= 0.4.2
+    templateflow >= 0.5.2
 test_requires =
     coverage
     codecov


### PR DESCRIPTION
This bumps the minimum niworkflows version to be in line with fmriprep 20.1.x