### PR TITLE
FIX: ensure bias_corrected is single file, not list

### DIFF
--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -345,7 +345,7 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823,
         (anat_validate, brain_extraction_wf, [
             ('out_file', 'inputnode.in_files')]),
         (brain_extraction_wf, outputnode, [
-            ('outputnode.bias_corrected', 't1w_preproc')]),
+            (('outputnode.bias_corrected', _pop), 't1w_preproc')]),
         (anat_template_wf, outputnode, [
             ('outputnode.t1w_realign_xfm', 't1w_ref_xfms')]),
         (buffernode, outputnode, [('t1w_brain', 't1w_brain'),


### PR DESCRIPTION
all other connections of `brain_extraction_wf.outputnode.bias_corrected` call `_pop()` to ensure singular file is passed. this PR apply that principle to the outputnode as well.