### PR TITLE
FIX: Correct the ``dseg`` labeling from FSL FAST earlier

### DIFF
--- a/smriprep/utils/misc.py
+++ b/smriprep/utils/misc.py
@@ -1,0 +1,23 @@
+"""Self-contained utilities to be used within Function nodes."""
+
+
+def apply_lut(in_dseg, lut, newpath=None):
+    """Map the input discrete segmentation to a new label set (lookup table, LUT)."""
+    import numpy as np
+    import nibabel as nb
+    from nipype.utils.filemanip import fname_presuffix
+
+    if newpath is None:
+        from os import getcwd
+        newpath = getcwd()
+
+    out_file = fname_presuffix(in_dseg, suffix='_dseg', newpath=newpath)
+    lut = np.array(lut, dtype='int16')
+
+    segm = nb.load(in_dseg)
+    hdr = segm.header.copy()
+    hdr.set_data_dtype('int16')
+    segm.__class__(lut[np.asanyarray(segm.dataobj, dtype=int)].astype('int16'),
+                   segm.affine, hdr).to_filename(out_file)
+
+    return out_file

--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -328,7 +328,7 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823,
     # Change LookUp Table - BIDS wants: 0 (bg), 1 (gm), 2 (wm), 3 (csf)
     lut_t1w_dseg = pe.Node(niu.Function(function=_apply_bids_lut),
                            name='lut_t1w_dseg')
-    lut_t1w_dseg.inputs.lut = [0, 3, 1, 2]  # Maps: 0 -> 0, 3 -> 1, 1 -> 2, 2 -> 3.
+    lut_t1w_dseg.inputs.lut = (0, 3, 1, 2)  # Maps: 0 -> 0, 3 -> 1, 1 -> 2, 2 -> 3.
 
     workflow.connect([
         (buffernode, t1w_dseg, [('t1w_brain', 'in_files')]),


### PR DESCRIPTION
Postponing this relabeling created a deviation of the derivative written
out to the hard disk and the actual file passed on by the outputnode.

This PR should serve as a basis for the elimination of FSL FAST in
``recon-all`` -based workflows (cc/ @mgxd):

  - FAST and the new tailgating node should be moved inside the if
    branch for ``--fs-no-reconall``
  - The LUT mapping function should be reused to remap FS's ``aseg``
    into a 3-tissue brain segmentation.

Resolves: #176
Related: #170
Related: poldracklab/fmriprep#1175