### PR TITLE
ENH: Execute FSL FAST only with ``--fs-no-reconall``

### DIFF
--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -634,6 +634,18 @@ def _pop(inlist):
 
 
 def _aseg_to_three():
+    """
+    Map FreeSurfer's segmentation onto a brain (3-)tissue segmentation.
+
+    This function generates an index of 255+0 labels and maps them into zero (bg),
+    1 (GM), 2 (WM), or 3 (CSF). The new values are set according to BIDS-Derivatives.
+    Then the index is populated (e.g., label 3 in the original segmentation maps to label
+    1 in the output).
+    The `aseg lookup table
+    <https://github.com/freesurfer/freesurfer/blob/2beb96c6099d96508246c14a24136863124566a3/distribution/ASegStatsLUT.txt>`__
+    is available in the FreeSurfer source.
+
+    """
     import numpy as np
     # Base struct
     aseg_lut = np.zeros((256,), dtype="int")

--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -431,7 +431,7 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823,
         return workflow
 
     # Map FS' aseg labels onto three-tissue segmentation
-    lut_t1w_dseg.inputs.lut = _aseg_two_three()
+    lut_t1w_dseg.inputs.lut = _aseg_to_three()
     split_seg = pe.Node(niu.Function(function=_split_segments),
                         name='split_seg')
 
@@ -633,7 +633,7 @@ def _pop(inlist):
     return inlist
 
 
-def _aseg_two_three():
+def _aseg_to_three():
     import numpy as np
     # Base struct
     aseg_lut = np.zeros((256,), dtype="int")
@@ -676,10 +676,9 @@ def _split_segments(in_file):
     hdr.set_data_dtype('uint8')
 
     out_files = []
-    for i, label in enumerate(("CSF", "WM", "GM")):
-        out_fname = str((Path() / f"aseg_label-{label}_mask.nii.gz").absolute())
-        segment = (data == i + 1).astype('uint8')
-        segimg.__class__(segment, segimg.affine, hdr).to_filename(out_fname)
+    for i, label in enumerate(("CSF", "WM", "GM"), 1):
+        out_fname = str(Path.cwd() / f"aseg_label-{label}_mask.nii.gz")
+        segimg.__class__(data == i, segimg.affine, hdr).to_filename(out_fname)
         out_files.append(out_fname)
 
     return out_files


### PR DESCRIPTION
This PR restructures the anatomical workflow so that the ``recon-all``
based graph does not execute FSL FAST, and rather projects the
``aseg`` segmentation to a 3-tissue brain segmentation with labels
according to BIDS.

This should provide the confounds workflow of *fMRIPrep* with smoother
(and probably more accurate) regions (e.g., for aCompCor calculations).
On the long run, we hope this will add some extra run-to-run
reproducibility to the aCompCor calculations.

Resolves: #170