### PR TITLE
FIX: Revise tissue probability maps connections and order

### DIFF
--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -422,7 +422,7 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823,
                 ('outputnode.out_mask', 't1w_mask')]),
             (buffernode, t1w_dseg, [('t1w_brain', 'in_files')]),
             (t1w_dseg, lut_t1w_dseg, [('tissue_class_map', 'in_dseg')]),
-            (t1w_dseg, fast2bids, [('tissue_class_map', 'inlist')]),
+            (t1w_dseg, fast2bids, [('probability_maps', 'inlist')]),
             (fast2bids, anat_norm_wf, [('out', 'inputnode.moving_tpms')]),
             (fast2bids, outputnode, [('out', 't1w_tpms')]),
         ])


### PR DESCRIPTION
This PR amends reminding problems in the label assigments of tissue
probability maps after #183.

Resolves: #189
References: #183