### PR TITLE
FIX: Use t1w2fsnative_xfm to resample segmentations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,7 +247,8 @@ jobs:
             pyenv local $PY2
             echo -n "Python version: "
             python --version
-            pip install --upgrade pip setuptools
+            pip install --upgrade "pip<21"
+            pip install --upgrade setuptools
             pip install --upgrade wrapper/
             which smriprep-docker
             smriprep-docker -i poldracklab/smriprep:latest --help

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -232,7 +232,7 @@ linkcode_resolve = make_linkcode_resolve('smriprep',
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
-    'niworkflows': ('https://poldracklab.github.io/niworkflows/', None),
+    'niworkflows': ('https://www.nipreps.org/niworkflows/', None),
 }
 
 # -- Options for versioning extension ----------------------------------------


### PR DESCRIPTION
Closes #154.

As noted in #154, if fsnative is not pre-aligned with the T1w template fMRIPrep produces, aparc/aseg do not get properly aligned, and due to using FreeSurfer outputs to refine the brainmask, everything suffers.

This first pipes the `t1w2fsnative_xfm` to the segmentation workflows (`init_segs_to_native_wf`). This workflow had used `mri_label2vol` + `mri_convert`. The `mri_label2vol` was already converting to NIfTI, so I dropped `mri_convert`.

I manually confirmed that using `mri_label2vol` with the *inverse* LTA gets the alignment right.

I also noticed that `mri_label2vol` has label, annotation and volume modes. Since `aseg.mgz` and `aparc+aseg.mgz` are already volumes (`.mgz`, rather than `.label` or `.annot`), I checked whether `mri_vol2vol` could be used.

That also worked. Even better, it takes its transforms in the usual direction (source -> target), so we don't have to leave comments about why we either pass the inverted LTA file, or pass the normal file and an "invert" flag.

Because the interface changed, I changed the name of the node.

---

Bug-fix status: This changes the workflow, *but* it does so in a way that should keep working directories reusable. And it fixes a bug in several versions of fMRIPrep. So I would suggest that we make an exception and release this as a bug-fix, which will allow us to fix the 20.0 and 20.1 series (and backport to 1.5, if it ever comes up).