### PR TITLE
FIX: Adapt to the new FS canary interface (backwards compatible)

### DIFF
--- a/smriprep/cli/run.py
+++ b/smriprep/cli/run.py
@@ -176,14 +176,8 @@ def build_opts(opts):
     warnings.showwarning = _warn_redirect
 
     # Precedence: --fs-license-file, $FS_LICENSE, default_license
-    fs_home = os.getenv("FREESURFER_HOME")
-    license_file = (
-        opts.fs_license_file
-        or os.getenv('FS_LICENSE')
-        or (os.path.join(fs_home, "license.txt") if fs_home else None)
-    )
-    if license_file and os.path.isfile(license_file):
-        os.environ["FS_LICENSE"] = license_file
+    if opts.fs_license_file is not None:
+        os.environ["FS_LICENSE"] = opts.fs_license_file
 
     if not check_valid_fs_license():
         raise RuntimeError(

--- a/smriprep/cli/run.py
+++ b/smriprep/cli/run.py
@@ -176,8 +176,16 @@ def build_opts(opts):
     warnings.showwarning = _warn_redirect
 
     # Precedence: --fs-license-file, $FS_LICENSE, default_license
-    license_file = opts.fs_license_file or os.getenv('FS_LICENSE')
-    if not check_valid_fs_license(lic=license_file):
+    fs_home = os.getenv("FREESURFER_HOME")
+    license_file = (
+        opts.fs_license_file
+        or os.getenv('FS_LICENSE')
+        or (os.path.join(fs_home, "license.txt") if fs_home else None)
+    )
+    if license_file and os.path.isfile(license_file):
+        os.environ["FS_LICENSE"] = license_file
+
+    if not check_valid_fs_license():
         raise RuntimeError(
             'ERROR: a valid license file is required for FreeSurfer to run. '
             'sMRIPrep looked for an existing license file at several paths, in this '

--- a/smriprep/cli/run.py
+++ b/smriprep/cli/run.py
@@ -177,7 +177,7 @@ def build_opts(opts):
 
     # Precedence: --fs-license-file, $FS_LICENSE, default_license
     if opts.fs_license_file is not None:
-        os.environ["FS_LICENSE"] = opts.fs_license_file
+        os.environ["FS_LICENSE"] = os.path.abspath(opts.fs_license_file)
 
     if not check_valid_fs_license():
         raise RuntimeError(


### PR DESCRIPTION
Addresses the problem discussed in nipreps/niworkflows#538 with a backwards compatible change (i.e., the canary function should work regardless of the nipreps 1.2.x used).

Closes #203.