### PR TITLE
FIX: Simplify canary logic, use new API

### DIFF
--- a/smriprep/cli/run.py
+++ b/smriprep/cli/run.py
@@ -175,9 +175,10 @@ def build_opts(opts):
 
     warnings.showwarning = _warn_redirect
 
-    # Precedence: --fs-license-file, $FS_LICENSE, default_license
-    license_file = opts.fs_license_file or os.getenv('FS_LICENSE')
-    if not check_valid_fs_license(lic=license_file):
+    if opts.fs_license_file is not None:
+        os.environ["FS_LICENSE"] = opts.fs_license_file
+
+    if not check_valid_fs_license():
         raise RuntimeError(
             'ERROR: a valid license file is required for FreeSurfer to run. '
             'sMRIPrep looked for an existing license file at several paths, in this '


### PR DESCRIPTION
Demonstrating my point in https://github.com/poldracklab/smriprep/pull/205#discussion_r436376339.

Assuming this works, it:

Closes #203.
Closes #205.